### PR TITLE
Solution- Person as Customer, PartyGroup as Supplier

### DIFF
--- a/udm/beginner/party.md
+++ b/udm/beginner/party.md
@@ -66,17 +66,46 @@ Sample JSON Data
     "postalCode": "12345",
     "countryGeoId": "USA"
   },
-  "ContactMechPurpose": [
+  "TelecomNumber": {
+    "contactMechId": "PHONE001",
+    "countryCode": "+91",
+    "areaCode": "45694",
+    "contactNumber": "99294"
+  },
+  "PartyContactMechPurpose": [
     {
+      "partyId": "CUST123",
       "contactMechId": "ADDR001",
-      "contactMechPurposeTypeId": "BILLING"
+      "contactMechPurposeTypeId": "BILLING_LOCATION",
+      "fromDate": "2024-01-23 00:00:00"
     },
     {
+      "partyId": "CUST123",
       "contactMechId": "ADDR001",
-      "contactMechPurposeTypeId": "SHIPPING"
+      "contactMechPurposeTypeId": "SHIPPING_LOCATION",
+      "fromDate": "2024-01-23 00:00:00"
+    },
+    {
+      "partyId": "CUST123",
+      "contactMechId": "PHONE001",
+      "contactMechPurposeTypeId": "PHONE_BILLING",
+      "fromDate": "2024-01-23 00:00:00"
+    }
+  ],
+  "PartyContactMech": [
+    {
+      "partyId": "CUST123",
+      "contactMechId": "ADDR001",
+      "fromDate": "2024-01-23 00:00:00"
+    },
+    {
+      "partyId": "CUST123",
+      "contactMechId": "PHONE001",
+      "fromDate": "2024-01-23 00:00:00"
     }
   ]
 }
+
 ```
 
 
@@ -90,7 +119,6 @@ Sample JSON Data
   "PartyGroup": {
     "partyId": "SUPP456",
     "groupName": "XYZ Supplies Inc.",
-    "taxId": "98-7654321"
   },
   "PartyRole": {
     "partyId": "SUPP456",
@@ -115,14 +143,42 @@ Sample JSON Data
     "postalCode": "54321",
     "countryGeoId": "USA"
   },
-  "ContactMechPurpose": [
+  "TelecomNumber": {
+    "contactMechId": "PHONE002",
+    "countryCode": "+91",
+    "areaCode": "45694",
+    "contactNumber": "99294"
+  },
+  "PartyContactMechPurpose": [
     {
+      "partyId": "SUPP456",
       "contactMechId": "ADDR002",
-      "contactMechPurposeTypeId": "BILLING"
+      "contactMechPurposeTypeId": "BILLING_LOCATION",
+      "fromDate": "2024-01-23 00:00:00"
     },
     {
+      "partyId": "SUPP456",
       "contactMechId": "ADDR002",
-      "contactMechPurposeTypeId": "SHIPPING"
+      "contactMechPurposeTypeId": "SHIPPING_LOCATION",
+      "fromDate": "2024-01-23 00:00:00"
+    },
+    {
+      "partyId": "SUPP456",
+      "contactMechId": "PHONE002",
+      "contactMechPurposeTypeId": "PHONE_BILLING",
+      "fromDate": "2024-01-23 00:00:00"
+    }
+  ],
+  "PartyContactMech": [
+    {
+      "partyId": "SUPP456",
+      "contactMechId": "ADDR002",
+      "fromDate": "2024-01-23 00:00:00"
+    },
+    {
+      "partyId": "SUPP456",
+      "contactMechId": "PHONE002",
+      "fromDate": "2024-01-23 00:00:00"
     }
   ]
 }


### PR DESCRIPTION
- Created the missing TelecomNumber entity to address its absence.
- Corrected the usage of an incorrect entity name, replaced it with the correct entity name (ContactMechPurpose ->PartyContactMechPurpose ).
- Utilized 'partyId' and 'fromDate' attributes in PartyContactMechPurpose, addressing the missing mandatory fields.
- Updated contactMechPurposeTypeId to 'BILLING_LOCATION' and 'SHIPPING_LOCATION' in PartyContactMechPurpose, ensuring correct usage.
- Implemented the creation of the missing PartyContactMech entity to connect ContactMech with Party.
- Added PartyContactMechPurpose for the phone number, addressing the omission.
- Removed a unnecessary 'textId' field from "PartyGroup" entity.