### PR TITLE
Clean up wording and evaluation criteria in Project Team Lead role

### DIFF
--- a/roles-responsibilities/project_team_lead_role_and_responsibilities.md
+++ b/roles-responsibilities/project_team_lead_role_and_responsibilities.md
@@ -17,13 +17,13 @@ The Team Lead ensures the team delivers outcomes while steadily raising:
 ### 1) Client delivery ownership
 - Own project outcomes: scope, timelines, risks, and delivery predictability.
 - Ensure work delivered each sprint adds measurable value for the customer.
-- Manage trade-offs (speed vs quality) without accumulating unmanaged technical debt.
+- Manage trade-offs between speed and quality without creating unmanaged technical debt.
 - Escalate early when requirements, dependencies, or risks threaten delivery.
 
 ### 2) Inception phase leadership (first 8 weeks)
 During project start, the Team Lead operates as **System Analyst + Solution Architect** (and may bill during this phase per project policy).
 
-**Deliverable: Inception Pack** (flexible depth; standard structure)
+**Deliverable: Inception Pack** (standard structure, adjusted to project needs)
 - Scope + In/Out + top risks
 - Workflow UML (main + alternate paths)
 - ERD (OOTB vs custom entities)
@@ -36,30 +36,30 @@ During project start, the Team Lead operates as **System Analyst + Solution Arch
 **Success definition:** After inception, implementation becomes predictable and verifiable.
 
 ### 3) Design-first engineering discipline
-For all non-trivial work, enforce “design before code”:
+For all non-trivial work, enforce design before code:
 - UML workflow + ERD + data state thinking
-- Clear mapping: workflow step → service → data mutation
-- Verification SQL and test cases are part of “done”
+- Clear mapping: workflow step -> service -> data mutation
+- Verification SQL and test cases are part of done
 
-The Team Lead ensures the team can **explain and defend** the design (not just implement it).
+The Team Lead ensures the team can **explain and defend** the design, not just implement it.
 
 ### 4) Quality and code stewardship
-- Enforce coding best practices and maintainable patterns.
-- Ensure strong PR reviews (correctness, readability, native OFBiz style).
-- Prevent “wrap-and-patch” development that degrades the codebase.
-- Ensure adequate tests and regression coverage for workflow-sensitive changes.
-- Maintain operational readiness: logging, error handling, consistency, idempotency where relevant.
+- Enforce maintainable coding practices.
+- Ensure strong PR reviews.
+- Prevent wrap-and-patch development that degrades the codebase.
+- Ensure adequate testing and regression coverage for important changes.
+- Maintain operational readiness: logging, error handling, consistency, and idempotency where needed.
 
 ### 5) OFBiz + domain mastery development
 The Team Lead ensures the team strengthens:
-- OOTB OFBiz codebase understanding
-- OOTB business workflows (Order-to-Cash, Procure-to-Pay)
-- Inventory, Fulfillment, Shipping, Receiving, Transfers, ATP/Brokering concepts (as relevant to the project)
+- OFBiz codebase understanding
+- OFBiz business workflows such as Order-to-Cash and Procure-to-Pay
+- Inventory, fulfillment, shipping, receiving, transfers, and ATP/brokering concepts as relevant to the project
 
-The Team Lead models “OFBiz expertise” by explaining the **why** behind patterns and decisions.
+The Team Lead models OFBiz expertise by explaining the **why** behind patterns and decisions.
 
 ### 6) Junior developer productivity (mandatory ownership)
-Because teams include junior developers, the Team Lead owns the responsibility to make each junior **productive within 6 months on the job**.
+Team Leads are responsible for making each junior developer productive within 6 months.
 
 **Productive means a junior can independently deliver a bounded change with:**
 - Workflow understanding
@@ -68,27 +68,26 @@ Because teams include junior developers, the Team Lead owns the responsibility t
 - Test cases / regression awareness
 - Minimal rework by seniors
 
-The Team Lead provides:
+The Team Lead must provide:
 - A ramp plan
-- Scoped ownership boundaries
+- Clear ownership boundaries
 - Structured reviews and coaching
-- Weekly visibility on junior progress
+- Weekly visibility on progress
 
 ### 7) AI in development enablement
 - Run one weekly team session on use of AI in development.
-- Get team members to share how they used AI during the week, what worked, what failed, and what they learned.
+- Have team members share how they used AI during the week, what worked, what failed, and what they learned.
 - Lead the discussion so the team learns from each other’s experience.
-- At the end of the session, document a few best practices the team agrees to follow.
-- Also define 1 or 2 experiments the team will try in the next week.
-- In the next session, review what happened and decide what to continue, change, or stop.
+- At the end of the session, document agreed best practices and 1 or 2 experiments for the next week.
+- In the next session, review results and decide what to continue, change, or stop.
 
 ### 8) Team culture and work discipline
 - Build a culture of punctuality, focus, and full productive workdays.
-- Ensure the team follows office schedule expectations and avoids “late start” normalization.
-- When performance is weak, first verify fundamentals: attendance, consistency, communication, planning discipline.
+- Ensure the team follows office schedule expectations and avoids late-start normalization.
+- When performance is weak, first check attendance, consistency, communication, and planning discipline.
 
-### 9) Communication and storytelling (twice monthly minimum)
-At the end of each sprint (at least twice a month), communicate the “life of the team/project”:
+### 9) Communication and project storytelling
+At the end of each sprint (at least twice a month), communicate the life of the team/project:
 - Achievements and learnings
 - Major client problems solved (business process / UX / operations)
 - Challenges and how they were addressed
@@ -102,18 +101,19 @@ Share this with:
 
 ## Time allocation model (OFBiz is treated as a second project)
 
-In addition to owning a client project, Team Leads are expected to treat **Apache OFBiz community contribution** as a focused, timeboxed “second project.” This strengthens individual expertise.
+In addition to owning a client project, Team Leads are expected to treat **Apache OFBiz community contribution** as a focused, timeboxed second project. This strengthens individual expertise.
+
+This is a guideline and may vary based on project stage and delivery needs.
 
 **Recommended weekly allocation (guideline):**
-
-* **50% Primary client project:** delivery governance, key decisions, design/reviews, risk management, client technical leadership
-* **25% OFBiz:** community outputs (answers/docs/patches/write-ups) planned on a small backlog
-* **25% Enablement:** mentoring juniors, improving team standards, running weekly AI-in-development sessions, and capturing best practices and experiments
+- **50% Primary client project:** delivery governance, key decisions, design/reviews, risk management, client technical leadership
+- **25% OFBiz:** community outputs (answers/docs/patches/write-ups) planned on a small backlog
+- **25% Enablement:** mentoring juniors, improving team standards, running weekly AI-in-development sessions, and capturing best practices and experiments
 
 ---
 
 ## Required Leadership Outputs
-The Team Lead must maintain a small set of visible working outputs that show planning, review, coaching, and improvement are happening regularly.
+The Team Lead must maintain a small set of visible outputs that show planning, review, coaching, and improvement are happening regularly.
 
 ### 1) Sprint Planning and Tracking
 - Keep a sprint plan for every sprint.
@@ -133,7 +133,7 @@ The Team Lead must maintain a small set of visible working outputs that show pla
 - Keep a project risk log and update it every week.
 - Add new risks as soon as they are identified.
 - For each risk, record impact, action, owner, and status.
-- Review open risks every week and update actions and status.
+- Review open risks every week.
 - Escalate risks early if they may affect scope, timeline, or quality.
 
 **Minimum fields:**
@@ -145,7 +145,7 @@ The Team Lead must maintain a small set of visible working outputs that show pla
 
 ### 3) Design Notes for Important Changes
 - Write design notes before development starts for important changes.
-- Use design notes for workflow changes, data model changes, integration changes, and other non-trivial work.
+- Use design notes for workflow changes, data model changes, integration changes, and other important technical changes.
 - Keep the design note simple and focused on the change being made.
 - Review the design note with the team when the change affects multiple people or modules.
 - Update the design note if the approach changes during implementation.
@@ -161,7 +161,7 @@ The Team Lead must maintain a small set of visible working outputs that show pla
 - Review pull requests for important changes before they are merged.
 - Give clear review comments when code needs correction, simplification, or better design.
 - Check that the change matches the agreed approach and does not create unnecessary technical debt.
-- Check that verification and test thinking are included where needed.
+- Check that verification steps and test thinking are included where needed.
 - Do not approve changes that are unclear, risky, or poorly understood.
 
 **Review should check:**
@@ -174,7 +174,7 @@ The Team Lead must maintain a small set of visible working outputs that show pla
 ### 5) Junior Developer Coaching
 - Keep short coaching notes for each junior developer.
 - Update the notes regularly based on code reviews, design discussions, and delivery work.
-- Record the junior’s current growth area, recent feedback, and next improvement step.
+- Record the junior's current growth area, recent feedback, and next improvement step.
 - Use the notes to track whether the junior is becoming more independent over time.
 - Review progress with the junior regularly.
 
@@ -213,9 +213,9 @@ The Team Lead must maintain a small set of visible working outputs that show pla
 ---
 
 ## What the Team Lead is evaluated on
-- Predictable delivery and client outcomes
-- Quality: defects, rework, support stability
-- Design discipline: quality of design artifacts and clarity of thinking
-- Team capability growth, especially junior productivity
-- Execution culture: discipline, accountability, operational maturity
-- Clear communication and leadership behaviors
+- Delivery predictability and client outcomes
+- Engineering quality, including defects, rework, and support stability
+- Design discipline and quality of design notes
+- Junior developer growth and team capability-building
+- Discipline in maintaining leadership outputs
+- Team execution culture, accountability, and communication


### PR DESCRIPTION
## Summary
- clean up wording across the Team Lead role document so sections read in one voice
- tighten repeated or overly long lines without changing the intent
- align the evaluation section with the role outputs and updated responsibilities

## Changes made
- simplified wording in core accountabilities
- tightened the AI enablement and junior productivity sections
- made the time allocation section clearly a guideline
- shortened the leadership outputs intro
- updated the evaluation section to match the rest of the document

## Why
The document is already strong. This pass makes it more consistent, practical, and easier to use as an operating document.
