### PR TITLE
docs: fix typos and improve NotNaked documentation suite

### DIFF
--- a/ubpl/NotNaked/BrokeringRequirements.md
+++ b/ubpl/NotNaked/BrokeringRequirements.md
@@ -30,11 +30,3 @@
 
 * **Minimum Split Value**  
    If an order needs splitting, each split portion should have a retail value of at least $50. If the partial split falls below that threshold, the system should keep the entire order together in one fulfillment location or highlight it as an exception.
-
----
-
-## **Related Documentation**
-*   [**Introduction**](Introduction.md)
-*   [**Setup Guide**](SetupGuide.md)
-*   [**Initial Requirements Checklist**](InitialRequirements.md)
-*   [**Experience OMS Flow**](ExperienceOmsFlow.md)

--- a/ubpl/NotNaked/BrokeringRequirements.md
+++ b/ubpl/NotNaked/BrokeringRequirements.md
@@ -30,3 +30,11 @@
 
 * **Minimum Split Value**  
    If an order needs splitting, each split portion should have a retail value of at least $50. If the partial split falls below that threshold, the system should keep the entire order together in one fulfillment location or highlight it as an exception.
+
+---
+
+## **Related Documentation**
+*   [**Introduction**](Introduction.md)
+*   [**Setup Guide**](SetupGuide.md)
+*   [**Initial Requirements Checklist**](InitialRequirements.md)
+*   [**Experience OMS Flow**](ExperienceOmsFlow.md)

--- a/ubpl/NotNaked/ExperienceOmsFlow.md
+++ b/ubpl/NotNaked/ExperienceOmsFlow.md
@@ -4,7 +4,7 @@ The purpose of this guide is to **Experience OMS** and see how orders flow from 
 
 
 ### 1. Shopify Order Import
-- As NotNaked uses Shopify as there e-com, order from there are imported into OMS in [**MDM**](https://dev-oms.hotwax.io/commerce/control/ShopifyImportData?configId=CRT_SHOPIFY_ORDER) using **Import Order Jobs**.  
+- As NotNaked uses Shopify as their e-commerce platform, orders from there are imported into OMS in [**MDM**](https://dev-oms.hotwax.io/commerce/control/ShopifyImportData?configId=CRT_SHOPIFY_ORDER) using **Import Order Jobs**.  
 - After import, a **process job** runs which stores all this data in the OMS database.
   
 **Beginner Task**:  
@@ -15,26 +15,26 @@ The purpose of this guide is to **Experience OMS** and see how orders flow from 
 
   Answer the following question:  
 
-    - How the order's data from Shofiy is stored in different entities?
+    - How is the order data from Shopify stored in different entities?
     - How is the order linked to the customer who placed it?
-    - What are the products in the order and at what quantity?
-    - What are the taxes imposed on the order?
-    - Where the order needs to be delivered?
-    - From where do the order needs to be fulfilled?
+    - How are products in the order identified, and at what quantity?
+    - What are the taxes applied to the order?
+    - Where does the order need to be delivered?
+    - Which facility is responsible for fulfilling the order?
 
-**Advance Task**:  
-Research on
+**Advanced Task**:  
+Research the following:  
 
-    - Which services are triggered behind the import orders job.  
-    - How is order indexed for the seach capabilities of sales order page.
-    - How is order approved in OMS.
+- Which services are triggered behind the **Import Orders** job.  
+- How the order is indexed for the search capabilities on the **Sales Order** page.  
+- How the order is approved in OMS.
 
 ---
 
 ## 2. Viewing the Order in OMS
 - After the Sales order is created in OMS, it can be viewed on the [**Sales Order page**](https://dev-oms.hotwax.io/commerce/control/FindOrder).  
-- Order is imported in created state and is approved at a regular interval by approve sales order job.
-- Approved orders are ready for facility allocation to get fullfiled.
+- Orders are imported in a **Created** state and are approved at regular intervals by the **Approve Sales Order** job.  
+- Approved orders are ready for facility allocation to begin the fulfillment process.
 ---
 
 ## 3. Order Brokering
@@ -49,11 +49,11 @@ Task: Notice how OMS assigns the order to a facility and prepares it for fulfill
 - Once the order is brokered to a facility, it can be [**fulfilled from that facility**](https://docs.hotwax.co/documents/store-operations/orders/fulfillment/ship-orders).  
 - Follow the pick, pack, and ship steps from the facility in OMS.
 
-Task: [Expereince fullfilment](https://fulfillment-dev.hotwax.io/login).
+Task: [Experience fulfillment](https://fulfillment-dev.hotwax.io/login).
 
 ---
 
-****Takeaways****
+## **Takeaways**
 - Focus on **experiencing the process**.
 - Let curiosity arise:
   - “How does OMS know which item goes to which facility?”

--- a/ubpl/NotNaked/Introduction.md
+++ b/ubpl/NotNaked/Introduction.md
@@ -89,12 +89,3 @@ NotNaked’s advanced operations are powered by an integrated technology stack:
 
 
 For managing unified orders, inventory, and fulfillment across all channels, NotNaked requires an [Enterprise-Level Application](https://www.ibm.com/think/topics/enterprise-applications). They selected [**HotWax Commerce**](https://www.hotwax.co/) — an **omnichannel Order Management System (OMS)** — as the backbone of their retail operations, enabling seamless integration across e-commerce, stores, warehouses, and logistics.
-
-## **Related Documentation**
-To understand the full scope of the NotNaked project, please refer to the following documents:
-
-*   [**Setup Guide**](SetupGuide.md): Step-by-step instructions for configuring the instance.
-*   [**Brokering Requirements**](BrokeringRequirements.md): Specific business logic for order allocation.
-*   [**Initial Requirements Checklist**](InitialRequirements.md): Technical and functional requirements for deployment.
-*   [**Experience OMS Flow**](ExperienceOmsFlow.md): A walkthrough of the order lifecycle from Shopify to fulfillment.
-*   [**Product Marketing Seed Data**](ProductMarketingSeed.md): Catalog and promotion strategy details.

--- a/ubpl/NotNaked/Introduction.md
+++ b/ubpl/NotNaked/Introduction.md
@@ -42,7 +42,7 @@ NotNaked operates retail locations in several cities. These stores function not 
    * **Address:** 700 SW 5th Avenue, Portland, OR 97204
 
 ## **Warehousing and Fulfillment Centers**
-NotNaked maintains warehouses at following locations.
+NotNaked maintains warehouses at the following locations.
 1. **Memphis, Tennessee**
    * *NotNaked Fulfillment Center – Memphis*  
    * **Address:** 1230 E Brooks Road, Memphis, TN 38116  
@@ -89,3 +89,12 @@ NotNaked’s advanced operations are powered by an integrated technology stack:
 
 
 For managing unified orders, inventory, and fulfillment across all channels, NotNaked requires an [Enterprise-Level Application](https://www.ibm.com/think/topics/enterprise-applications). They selected [**HotWax Commerce**](https://www.hotwax.co/) — an **omnichannel Order Management System (OMS)** — as the backbone of their retail operations, enabling seamless integration across e-commerce, stores, warehouses, and logistics.
+
+## **Related Documentation**
+To understand the full scope of the NotNaked project, please refer to the following documents:
+
+*   [**Setup Guide**](SetupGuide.md): Step-by-step instructions for configuring the instance.
+*   [**Brokering Requirements**](BrokeringRequirements.md): Specific business logic for order allocation.
+*   [**Initial Requirements Checklist**](InitialRequirements.md): Technical and functional requirements for deployment.
+*   [**Experience OMS Flow**](ExperienceOmsFlow.md): A walkthrough of the order lifecycle from Shopify to fulfillment.
+*   [**Product Marketing Seed Data**](ProductMarketingSeed.md): Catalog and promotion strategy details.


### PR DESCRIPTION
This PR addresses typos, grammatical errors, and formatting inconsistencies in the NotNaked project documentation.

### Changes:
- **BrokeringRequirements.md**: Standardized headings and added a "Related Documentation" section.
- **ExperienceOmsFlow.md**: Fixed typos (e.g., corrected "there" to "their"), improved professional tone, and clarified task descriptions.
- **Introduction.md**: Fixed grammar in the warehousing section and established a centralized documentation hub.

These updates ensure the documentation is consistent and ready for team onboarding.