### PR TITLE
docs: update D365 outbound shipment docs and add shipment export exploration

### DIFF
--- a/project-ideas/dynamics365-integration/README.md
+++ b/project-ideas/dynamics365-integration/README.md
@@ -14,6 +14,8 @@ The goal of this integration is to synchronize critical business data, specifica
     *   Technical research on available D365 integration patterns (OData, DIXF, Business Events).
 3.  **[Implementation Plan](sales-orders/implementation_plan.md)**
     *   Specific technical design, sequence flows, and step-by-step roadmap for development.
+4.  **[Shipment Export Exploration](sales-orders/shipment_export_exploration.md)**
+    *   Exploration notes for outbound shipment synchronization patterns from D365 to OMS.
 
 ### Sales Returns
 1.  **[D365 Return & Exchange Accounting Model](sales-returns/d365_return_exchange_accounting_model.md)**

--- a/project-ideas/dynamics365-integration/sales-orders/business_processes.md
+++ b/project-ideas/dynamics365-integration/sales-orders/business_processes.md
@@ -241,12 +241,17 @@ The following questions should be clarified with the D365 Finance/Functional tea
 
 ## 7. Outbound Notifications (D365 -> OMS)
 
-This section is retained as a future-state exploration area. I did not find corresponding outbound event handling implementation in the current `hotwax-d365` connector code reviewed for this pass.
+Outbound integration from D365 to OMS can be implemented through either event-driven notifications or data export patterns, depending on payload and filtering requirements.
 
 ### 7.1 Fulfillment Updates (Packing Slip)
 - **D365 Event**: `SalesOrderPackingSlipPostBusinessEvent` (or similar).
 - **Trigger**: When a packing slip is posted in D365.
 - **OMS Action**: Update shipment status to "Shipped" and record tracking information.
+- **Implementation options**:
+  - Business Event -> Logic App
+  - Business Event -> Azure Service Bus Queue -> Azure Function
+  - Custom shipment export entity -> DMF recurring export -> Azure Function
+- **Selection driver**: Choose the pattern based on payload completeness, filtering requirements, operational controls, and downstream transformation complexity.
 
 ### 7.2 Financial Updates (Invoice)
 - **D365 Event**: `SalesOrderInvoicedBusinessEvent`.
@@ -257,5 +262,14 @@ This section is retained as a future-state exploration area. I did not find corr
 - **Method**: D365 pushes a JSON payload to a Moqui REST endpoint via an HTTPS Webhook or Azure Power Automate.
 - **Payload**: Minimal event data (Event ID, Company, SalesOrderNumber) used by Moqui to then pull detailed data via OData if necessary.
 
-> [!TODO]
-> Confirm which D365 business events are actually available and intended for use in this project, then document the implementation path separately from the currently shipped connector behavior.
+### 7.4 Shipment Export Pattern (Data Entity + DMF)
+When outbound integration requires line-level filtering and combined header/line/tracking data, a custom flat export entity can be used.
+
+- **Requirement pattern**: Sync only a subset of shipment lines based on fulfillment source/business criteria.
+- **Entity composition**:
+  - `CustPackingSlipJourBiEntities` for header fields
+  - `CustPackingSlipTransBiEntities` for line fields
+  - `PackingSlipTrackingInformation` for tracking/carrier fields
+- **Export model**: Flat rows via DMF recurring integration.
+- **Transformation model**: Integration middleware polls recurring integration (`dequeue`/`ack`), groups rows by shipment key, and constructs OMS shipment JSON.
+- **Exploration details**: See [shipment_export_exploration.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md).

--- a/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md
+++ b/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md
@@ -1,4 +1,4 @@
-d# Technical Integration Methodologies
+# Technical Integration Methodologies
 
 This document explores the various technical patterns available for integrating with Dynamics 365 Finance & Operations.
 
@@ -106,3 +106,16 @@ Business events can be consumed through various endpoints:
 ### 4.3 Comparison: OData vs. Business Events
 - **OData (Pull)**: Best for synchronous CRUD or batch data retrieval where the OMS initiates the request.
 - **Business Events (Push)**: Best for reactive workflows where D365 must notify the OMS of a state change (e.g., fulfillment complete).
+
+---
+
+## 5. Shipment Export via Data Entities
+- **Goal**: Export shipment details with source-side filtering so only required fulfillment lines are synchronized to OMS.
+- **Source entities**:
+  - `CustPackingSlipJourBiEntities` (packing slip header)
+  - `CustPackingSlipTransBiEntities` (packing slip lines)
+  - `PackingSlipTrackingInformation` (tracking and carrier details)
+- **Entity grain**: One export row per shipment line (or per shipment line + tracking number, based on tracking cardinality).
+- **Export mechanism**: Data Management Framework (DMF) recurring export.
+- **Consumption mechanism**: Middleware polls recurring integration dequeue APIs, processes export packages, and acknowledges consumption.
+- **Payload shaping**: DMF exports tabular records; middleware groups rows (for example by `packingSlipId`) to construct nested OMS shipment payloads.

--- a/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md
+++ b/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md
@@ -1,0 +1,55 @@
+# Shipment Export from D365 to OMS - Exploration Notes
+
+## Objective
+Evaluate outbound shipment integration options from D365 to OMS, with a specific requirement to synchronize only shipment lines fulfilled through D365/WMS flows.
+
+## Requirement Context
+- Shipment data needs to include packing slip header, lines, and tracking information.
+- OMS-fulfilled lines should be excluded from outbound synchronization.
+- A single export run may contain multiple shipments.
+
+## Approaches Explored
+
+### 1. Business Event -> Logic App
+- D365 emits a business/data event on shipment-related process completion.
+- Logic App receives the event and forwards/transforms data for OMS.
+- Result: Validated as technically feasible in POC.
+
+### 2. Business Event -> Azure Service Bus Queue -> Azure Function
+- D365 emits event to Service Bus endpoint.
+- Azure Function consumes queued messages and performs transformation/routing.
+- Result: Validated as technically feasible in POC.
+
+### 3. Custom Flat Entity -> DMF Recurring Export -> Azure Function
+- A custom export entity combines:
+  - `CustPackingSlipJourBiEntities` (header)
+  - `CustPackingSlipTransBiEntities` (line)
+  - `PackingSlipTrackingInformation` (tracking/carrier)
+- Export runs through DMF recurring integration as tabular output.
+- Azure Function polls recurring integration (`dequeue`), processes package rows, groups by shipment key (for example `packingSlipId`), builds OMS nested shipment JSON, then calls `ack`.
+- Result: Selected exploration direction for line-level filtering and export-side data shaping.
+
+## Key Technical Observations
+
+### DMF Payload Shape
+DMF exports tabular records. Nested shipment JSON (`items[]`) must be assembled in middleware.
+
+### Grouping Responsibility
+Grouping is performed in Azure Function (or equivalent middleware), not in DMF entity export output.
+
+### Recurring Integration Behavior
+- Recurring jobs run on schedule and produce export packages.
+- Middleware must poll dequeue APIs on its own schedule (typically timer-triggered function).
+- After successful processing, middleware acknowledges the package to prevent reprocessing.
+
+## Decision Drivers for Final Selection
+- Ability to enforce D365/WMS-only line filtering.
+- Payload completeness in one extraction model.
+- Transformation complexity outside D365.
+- Operational reliability (retry, idempotency, backlog handling).
+- Long-term maintainability.
+
+## Related References
+- GitHub Issue: https://github.com/hotwax/hotwax-d365/issues/51
+- Business process reference: [business_processes.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/business_processes.md)
+- Integration methodology reference: [integration_methodologies.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md)


### PR DESCRIPTION
## Summary
- update D365 sales-order integration docs with factual outbound shipment integration patterns
- add implementation options under fulfillment updates (business events + logic app, business events + service bus + function, custom entity + DMF + function)
- add a dedicated shipment export exploration document
- link shipment export exploration from dynamics365-integration README

## Files
- `project-ideas/dynamics365-integration/README.md`
- `project-ideas/dynamics365-integration/sales-orders/business_processes.md`
- `project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md`
- `project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md`