### PR TITLE
Document targeted dequeue by messageId for recurring export flows

### DIFF
--- a/project-ideas/dynamics365-integration/recurring-integrations/recurring_integrations_api.md
+++ b/project-ideas/dynamics365-integration/recurring-integrations/recurring_integrations_api.md
@@ -120,6 +120,40 @@ After successfully downloading and processing the export package, you must send 
 * **API Correlation ID:** The `CorrelationId` in the `/dequeue` JSON response is a *temporary lease lock token* used to link the dequeue session to the acknowledgment POST payload.
 * **Mapping:** D365 resolves the `CorrelationId` internally on `/ack` POST ingestion, updates the corresponding database message record (e.g. `{1EB6FF02-...}`), and updates its status to **Acknowledged** in the UI.
 
+### 2.5 Targeted Dequeue by Message ID
+The standard dequeue endpoint always retrieves the **next available message** from the head of the queue. D365 supports an optional `messageId` query parameter to target a **specific message** by its persistent database record GUID (the **UI Message ID** from section 2.4):
+
+* **Endpoint:** `GET https://<d365-instance-url>/api/connector/dequeue/<activity-id>?messageId=<ui-message-id-guid>`
+* **Behaviour:** D365 locates the specific queue message matching that GUID and returns it in the same `200 OK` JSON response as a standard dequeue call.
+* **Response (HTTP 200):** Identical structure to a normal dequeue response:
+  ```json
+  {
+    "CorrelationId": "81037098-0d8d-4d52-80b5-7cd37c4f1641",
+    "PopReceipt": "AgAAAAMAAAAAAAAA45VJANDx3AE=",
+    "DownloadLocation": "https://<d365-instance-url>/api/connector/download/...",
+    "IsDownLoadFileExist": true,
+    "FileDownLoadErrorMessage": null,
+    "LastDequeueDateTime": null
+  }
+  ```
+* **Ack behaviour:** The resulting `CorrelationId` and `PopReceipt` must still be passed back to `/ack` after processing, exactly as in a standard dequeue flow. The 30-minute lease lock applies equally.
+
+#### When to Use
+| Scenario | Recommendation |
+| :--- | :--- |
+| Normal continuous export polling | Standard dequeue (no `messageId`) |
+| Re-processing a specific failed or stuck message | Pass the UI Message ID via `?messageId=` |
+| Debugging — inspecting a specific package without consuming the queue head | Pass the UI Message ID; the file download can be inspected before ack |
+| Manual re-run after an OMS-side error that was already acknowledged in D365 | Not possible via dequeue; the message has been removed from the queue |
+
+#### OMS Implementation
+The `dequeue#RecurringSalesOrderNumbers` service accepts an optional `messageId` parameter. When provided, it appends `?messageId=<value>` to the dequeue URL. The rest of the flow — download, unzip, DataManager upload, and ack — is identical to the standard path.
+
+The `d365_DequeueRecurringSalesOrderNumbers` ServiceJob exposes a `messageId` parameter slot (empty by default). To trigger a targeted re-run, set this parameter to the UI Message ID GUID from the D365 **View messages** screen, run the job once manually, then clear the parameter back to empty so subsequent scheduled runs return to normal queue polling.
+
+> [!NOTE]
+> The UI Message ID used here is the **persistent database GUID** shown in the D365 "Manage messages" screen — **not** the `CorrelationId` returned by the dequeue response, which is a temporary lease token.
+
 ---
 
 ## 3. D365 UI Monitoring & Administration

--- a/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
+++ b/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
@@ -1010,6 +1010,7 @@ To bypass request-driven generation and polling overhead, this flow active-polls
 1. **The Dequeue Service (`dequeue#RecurringSalesOrderNumbers`):**
    - Triggered on a cron schedule via the Service Job `d365_DequeueRecurringSalesOrderNumbers`.
    - Sends an authenticated `GET` call to `/api/connector/dequeue/{activityId}`.
+   - **Targeted dequeue (optional):** When the `messageId` parameter is set on the service or job, the URL becomes `/api/connector/dequeue/{activityId}?messageId={messageId}`, targeting that specific queue message instead of the head of the queue. See [Targeted Dequeue by Message ID](../recurring-integrations/recurring_integrations_api.md#25-targeted-dequeue-by-message-id) for details.
    - If empty, D365 returns `204 No Content` and the service terminates gracefully.
    - If a package is ready, D365 returns `200 OK` with a JSON payload containing the `CorrelationId`, `PopReceipt`, and `DownloadLocation`.
    - The service makes a secondary `GET` call to the `DownloadLocation` URL (passing the OAuth Bearer token) to download the ZIP package, unzips it in-memory, extracts the target CSV file, and registers it with the Maarg DataManager (`D365_IMP_SALES_ORD`).
@@ -1019,6 +1020,16 @@ To bypass request-driven generation and polling overhead, this flow active-polls
    - Sends a `POST` request to `/api/connector/ack/{activityId}`.
    - Passes the **exact JSON payload** received from the dequeue request in the POST body.
    - D365 resolves the `CorrelationId` and lease lock, permanently deletes the message from the queue, and marks the corresponding message status in the D365 UI as **Acknowledged**.
+
+###### Targeted Re-run / Debugging
+To re-process a specific export message without consuming the queue head:
+1. Look up the **Message ID** GUID from the D365 UI: **System administration > Data management IT > Manage scheduled data jobs > View messages**.
+2. Set the `messageId` parameter on the `d365_DequeueRecurringSalesOrderNumbers` ServiceJob to that GUID.
+3. Run the job once manually.
+4. Clear the `messageId` parameter back to empty so subsequent scheduled runs return to normal queue polling.
+
+> [!NOTE]
+> This only works for messages that are still **in the queue** (status `In queue` or within the 30-minute lease window). Messages that have already been **Acknowledged** are permanently removed from the queue and cannot be re-dequeued.
 
 ---
 


### PR DESCRIPTION
## Summary
- Added Section 2.5 to `recurring_integrations_api.md` documenting the `?messageId=` query parameter on the D365 dequeue API, with a usage decision table, sample response, and OMS implementation notes
- Updated `implementation_plan.md` Export Approach 2 with the optional `messageId` parameter on `dequeue#RecurringSalesOrderNumbers` and a step-by-step targeted re-run procedure for debugging and error recovery

## Test Plan
- [ ] Review Section 2.5 in `recurring_integrations_api.md` for accuracy against the D365 API behaviour
- [ ] Verify the targeted re-run steps in `implementation_plan.md` match the implementation in [hotwax-d365#feature/dequeue-by-message-id](https://github.com/hotwax/hotwax-d365/tree/feature/dequeue-by-message-id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)