### PR TITLE
docs: document HcFulfillmentType in order sync and add D365 data proj…

### DIFF
--- a/project-ideas/dynamics365-integration/README.md
+++ b/project-ideas/dynamics365-integration/README.md
@@ -30,3 +30,5 @@ The goal of this integration is to synchronize critical business data, specifica
     *   Documentation and APIs for pushing DMF packages to D365.
 2.  **[Data Import Package API](data-package-api/data_import_package_api.md)**
     *   Documentation and APIs for polling DMF export packages from D365.
+3.  **[Updating Field Mappings in an Existing Data Project](data-package-api/data_project_field_mapping_update.md)**
+    *   Step-by-step procedure for updating a D365 data project when a new field is added to a feed, including the correct Load project → Upload file → Regenerate mapping flow.

--- a/project-ideas/dynamics365-integration/data-package-api/data_project_field_mapping_update.md
+++ b/project-ideas/dynamics365-integration/data-package-api/data_project_field_mapping_update.md
@@ -1,0 +1,64 @@
+# Updating Field Mappings in an Existing D365 Data Project
+
+When a new field is added to a data package feed (e.g., a new column added to a CSV or a new attribute in a composite XML), the corresponding D365 data project must be updated to include that field in its source-to-staging mapping.
+
+## When This Is Needed
+
+- A new field is added to an existing OMS connector feed (e.g., `HCFULFILLMENTTYPE` added to `HotWax_Import_Brokered_Order_Items`)
+- A new field is added to an existing composite entity (e.g., a new attribute on `SALESORDERLINEV2ENTITY` inside `HotWax_Import_SalesOrders_Composite`)
+- The mapping was set up with an older sample file that did not include the new column
+
+## Understanding the Mapping View
+
+In D365 Data Management, **View Map** shows two columns:
+
+| Column | What it represents |
+| :--- | :--- |
+| **Source field** | Columns derived from the sample file uploaded when the project was set up. New columns do not appear here until a new file is uploaded. |
+| **Staging field** | All columns available in the D365 entity's staging table. A new field on the entity appears here immediately, but has nothing mapped to it until the source is updated. |
+
+This means you cannot simply add a manual mapping for a new field — the Source field column will not show it until D365 has seen a file that contains it.
+
+## Steps to Update the Mapping
+
+1. **Go to Data Management workspace** → **Data projects**.
+
+2. **Select the data project** you want to update (e.g., `HotWax_Import_Brokered_Order_Items`).
+
+3. **Click `Load project`** (not `Run project`, and do not click into the project to open it). The `Load project` option appears in the action bar when the project row is selected.
+
+4. **Click `Upload file`** and upload a new sample file that includes the new field column.
+   - For CSV-based projects: upload a CSV with the new column header included (a single data row is sufficient).
+   - For XML/composite projects: upload a new sample XML that includes the new attribute on the relevant entity element.
+
+5. **Go back** to the Data projects list.
+
+6. **Click the data project name** to open it this time.
+
+7. Inside the project, find the entity tile (e.g., `Sales order lines V3`) and click **View map**.
+
+8. Click **Regenerate source mapping** (or **Generate source mapping** depending on the D365 version).
+   - D365 will ask: *"Do you want to generate the mapping from scratch?"* → click **Yes**.
+   - The new field now appears in the Source field column and is automatically mapped to the matching Staging field.
+
+9. **Verify** that the new field appears in the mapping with a Source → Staging connection.
+
+> [!NOTE]
+> `Load project` + `Upload file` is the correct entry point for replacing the sample file on an existing project. Opening the project directly and using `Add file` or `Run project` serves a different purpose and may not correctly replace the existing entity's source file.
+
+## Example: Adding `HCFULFILLMENTTYPE` to `HotWax_Import_Brokered_Order_Items`
+
+Upload a new `Sales order lines V3.csv` sample:
+
+```csv
+INVENTORYLOTID,SHIPPINGWAREHOUSEID,HCFULFILLMENTTYPE
+479494,13,WMS
+```
+
+After regenerating the source mapping, the mapping should show:
+
+| Source field | Staging field |
+| :--- | :--- |
+| INVENTORYLOTID | INVENTORYLOTID |
+| SHIPPINGWAREHOUSEID | SHIPPINGWAREHOUSEID |
+| HCFULFILLMENTTYPE | HCFULFILLMENTTYPE |

--- a/project-ideas/dynamics365-integration/sales-orders/business_processes.md
+++ b/project-ideas/dynamics365-integration/sales-orders/business_processes.md
@@ -217,8 +217,12 @@ Store-fulfilled order items are physically picked, packed, and shipped within OM
 2. **OMS fulfills the order** — pick, pack, ship.
 3. **OMS sends the fulfilled location update to D365** via the `HotWax_Import_Fulfilled_Order_Items` data package.
    - Entity: `Sales order lines V3`
-   - Field updated: `SHIPPINGWAREHOUSEID` (the store's D365 warehouse ID from `Facility.externalId`)
+   - Fields updated: `SHIPPINGWAREHOUSEID` (the store's D365 warehouse ID from `Facility.externalId`) and `HCFULFILLMENTTYPE = OMS`
    - Prerequisite: `D365_SLS_ORD_NUM` and `D365SalesOrderItemInventoryLotId` must already be resolved in OMS.
+
+> [!NOTE]
+> If the order was already brokered to a store when it was first synced to D365, `HcFulfillmentType = OMS` is set on the line at initial order creation time. The fulfilled items feed reinforces this value and adds the final `SHIPPINGWAREHOUSEID`.
+
 4. **D365 posts the packing slip** via an OOTB batch job filtered on the custom field `HcFulfillmentType = OMS`:
    - Navigation: `Sales and marketing > Order shipping > Post packing slip`
    - Query filters: `Sales Order Line HC Fulfillment Type = OMS`, Sales Order status = `Open order, Delivered`
@@ -232,8 +236,11 @@ Warehouse-fulfilled order items are handed off to D365 after brokering. D365 own
 1. **OMS brokers the order item** to a warehouse facility that has a D365 warehouse mapping (`Facility.externalId`).
 2. **OMS sends the brokered warehouse location to D365** via the `HotWax_Import_Brokered_Order_Items` data package.
    - Entity: `Sales order lines V3`
-   - Field updated: `SHIPPINGWAREHOUSEID`
+   - Fields updated: `SHIPPINGWAREHOUSEID` (the final warehouse) and `HCFULFILLMENTTYPE = WMS`
    - Prerequisite: `D365_SLS_ORD_NUM` and `D365SalesOrderItemInventoryLotId` must already be resolved in OMS.
+
+> [!NOTE]
+> If the order was already brokered to a warehouse when it was first synced to D365, `HcFulfillmentType = WMS` is set on the line at initial order creation time. The brokered items feed reinforces this value and updates `SHIPPINGWAREHOUSEID` with the final warehouse once brokering is confirmed.
 3. **D365 owns all fulfillment from this point** — warehouse staff pick and pack using D365 WMS flows, and D365 posts the packing slip as part of its shipping confirmation process.
 4. **D365 pushes shipment data back to OMS** after packing slip posting so OMS can mark the warehouse-fulfilled order items as shipped/completed. See [Section 9 — Outbound Notifications](#9-outbound-notifications-d365---oms) and [shipment_export_exploration.md](./shipment_export_exploration.md).
 

--- a/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
+++ b/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
@@ -246,7 +246,8 @@ This is a fully implemented direct-sync path that creates a sales order header a
 | `ProductSizeId` | `ProductFeature(SIZE)` | Sent when the OMS item exposes a size feature. |
 | `ProductColorId` | `ProductFeature(COLOR)` | Sent when the OMS item exposes a color feature. |
 | `shipmentMethodTypeId` | `OrderItemShipGroup.shipmentMethodTypeId` | Used to derive the order-level `DeliveryModeCode`. |
-| `ShippingWarehouseId` | `item.shippingWarehouseId` | Sent only for `WH_ONLY_FULFILLMENT` items. |
+| `ShippingWarehouseId` | `item.shippingWarehouseId` | Populated only when `HcFulfillmentType = WMS`; empty string otherwise. |
+| `HcFulfillmentType` | `D365MappingWorker.getHcFulfillmentType(facilityId)` | Set at order creation time if the fulfillment path is already known: `WMS` (facility in `WH_ONLY_FULFILLMENT`), `OMS` (facility in `OMS_FULFILLMENT`), or omitted if not yet brokered. Will be set later by the brokered/fulfilled item update feeds. |
 
 ##### OData Idempotency and Failure Behavior
 - **Header idempotency key**: `CustomersOrderReference`
@@ -641,7 +642,8 @@ After OMS confirms the remote execution and completes follow-up processing, the 
 | `PRODUCTSIZEID` | `ProductFeature(SIZE)` | Sent when the OMS item exposes a size feature. |
 | `PRODUCTCOLORID` | `ProductFeature(COLOR)` | Sent when the OMS item exposes a color feature. |
 | `shipmentMethodTypeId` | `OrderItemShipGroup.shipmentMethodTypeId` | Used to derive the order-level `DELIVERYMODECODE`. |
-| `SHIPPINGWAREHOUSEID` | `shippingWarehouseId` | Sent for D365 fulfillment warehouse use case. |
+| `SHIPPINGWAREHOUSEID` | `shippingWarehouseId` | Populated only when `HCFULFILLMENTTYPE = WMS`; empty string otherwise. |
+| `HCFULFILLMENTTYPE` | `D365MappingWorker.getHcFulfillmentType(facilityId)` | Set at order creation time if the fulfillment path is already known: `WMS` (facility in `WH_ONLY_FULFILLMENT`), `OMS` (facility in `OMS_FULFILLMENT`), or omitted if not yet brokered. Will be set later by the brokered/fulfilled item update feeds. |
 
 ###### DMF Shipment Method Handling
 - The eligible-order view also exposes `isMixCartOrder` so order-level delivery mode can be derived consistently.
@@ -1166,9 +1168,9 @@ Once OMS has final brokered fulfillment location information, it can update the 
 - **Validated file shape**:
 
 ```csv
-INVENTORYLOTID,SHIPPINGWAREHOUSEID
-479494,100
-479495,13
+INVENTORYLOTID,SHIPPINGWAREHOUSEID,HCFULFILLMENTTYPE
+479494,100,WMS
+479495,13,WMS
 ```
 
 - `DATAAREAID` is intentionally not included in the file. The OMS service requires `dataAreaId` as an input parameter and passes it to D365 as `legalEntityId` in the `ImportFromPackage` request.
@@ -1219,9 +1221,9 @@ Once OMS has physically fulfilled a store-owned line, it can update the D365 sal
 - **Validated file shape**:
 
 ```csv
-INVENTORYLOTID,SHIPPINGWAREHOUSEID
-479494,100
-479495,13
+INVENTORYLOTID,SHIPPINGWAREHOUSEID,HCFULFILLMENTTYPE
+479494,100,OMS
+479495,13,OMS
 ```
 
 - `DATAAREAID` is intentionally not included in the file. The OMS service requires `dataAreaId` as an input parameter and passes it to D365 as `legalEntityId` in the `ImportFromPackage` request.
@@ -1247,6 +1249,16 @@ INVENTORYLOTID,SHIPPINGWAREHOUSEID
 - `OrderFulfillmentHistory` is used only as a sent marker here; the full D365 execution id is not stored on that entity because the value can exceed the local field length.
 - If a fulfilled-item package fails in D365 and the same item needs to be re-sent, the corresponding `OrderFulfillmentHistory` row must be removed or otherwise cleared for retry.
 - Because reservation is currently manual in the tested D365 setup, this fulfilled-location update is expected to be safe before downstream D365 posting. If D365 reservation or posting behavior changes, this assumption must be retested.
+
+> [!TODO]
+> **Revisit: single vs. separate D365 data projects for brokered and fulfilled item updates.**
+> Both feeds now send identical fields to D365 (`INVENTORYLOTID`, `SHIPPINGWAREHOUSEID`, `HCFULFILLMENTTYPE`) against the same entity (`Sales order lines V3`). A single D365 data project (`HotWax_Import_Order_Item_Updates`) could technically serve both, since D365 does not distinguish between brokered and fulfilled items — it just updates the sales order line.
+>
+> **Reasons to consolidate:** fewer D365 data projects to maintain and configure.
+>
+> **Reasons to keep separate:** independent scheduling frequency (brokered items should be sent as soon as brokering is confirmed; fulfilled items are sent after physical shipment), independent monitoring and failure isolation, and the ability for each flow to evolve its field set independently if future requirements differ (e.g., adding a tracking number or fulfillment timestamp to the fulfilled items feed).
+>
+> If the two feeds remain field-identical over time and operational simplicity is preferred, consolidation into a single D365 data project is a valid option.
 
 ## Customer Payment Integration
 


### PR DESCRIPTION
…ect maintenance guide

Update implementation_plan.md:
- Add HcFulfillmentType / HCFULFILLMENTTYPE to OData (SalesOrderLinesV3) and DMF (SALESORDERLINEV2ENTITY) line mapping tables, noting it is set at initial order creation time when the fulfillment path is already known (WMS = WH_ONLY_FULFILLMENT, OMS = OMS_FULFILLMENT, omitted if not yet brokered).
- Update ShippingWarehouseId notes to reflect it is now only populated when HcFulfillmentType = WMS.
- Update brokered and fulfilled item feed file shapes to include HCFULFILLMENTTYPE column.
- Add TODO after section 3.1 to revisit whether brokered and fulfilled item feeds could share a single D365 data project, with reasons to consolidate and reasons to keep separate.

Update business_processes.md:
- Section 5.1 (Store Fulfillment): note HCFULFILLMENTTYPE = OMS sent in fulfilled items feed; add note that it may already be set at initial sync if order was brokered to a store before sync ran.
- Section 5.2 (Warehouse Fulfillment): note HCFULFILLMENTTYPE = WMS sent in brokered items feed; add note that it may already be set at initial sync if order was brokered to a warehouse before sync ran.

Add data_project_field_mapping_update.md:
- Step-by-step procedure for updating field mappings in an existing D365 data project when a new column is added to a feed: Load project → Upload file → open project → View map → Regenerate source mapping.
- Explains Source field vs Staging field distinction.
- Includes concrete example for HCFULFILLMENTTYPE.

Update README.md to include new data project maintenance doc.