### PR TITLE
docs: document D365 arrival journal DMF sync implementation

### DIFF
--- a/project-ideas/dynamics365-integration/README.md
+++ b/project-ideas/dynamics365-integration/README.md
@@ -3,7 +3,7 @@
 This repository serves as a central research and design hub for the integration between HotWax OMS and Microsoft Dynamics 365 Finance & Operations (D365 F&O).
 
 ## Overview
-The goal of this integration is to synchronize critical business data, specifically Customers and Sales Orders, to enable seamless financial and supply chain operations.
+The goal of this integration is to synchronize critical business data, specifically Customers, Sales Orders and Returns, to enable seamless financial and supply chain operations in Dynamics 365.
 
 ## Documentation Flow
 

--- a/project-ideas/dynamics365-integration/data-package-api/data_export_package_api.md
+++ b/project-ideas/dynamics365-integration/data-package-api/data_export_package_api.md
@@ -107,26 +107,26 @@ This is the current export model and the implemented generic framework.
 
 #### Generic services in this approach
 - **Generic queue service**
-  - Service: [D365DataPackageServices.queue#ExportDataPackage](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:4)
+  - Service: `D365DataPackageServices.queue#ExportDataPackage`
   - Responsibility:
     - validate export-specific inputs
     - build the export payload JSON
     - call `org.moqui.impl.SystemMessageServices.queue#SystemMessage`
     - queue the message with `sendNow=true`
 - **Generic send service**
-  - Service: [D365DataPackageServices.send#ExportDataPackage](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:40)
+  - Service: `D365DataPackageServices.send#ExportDataPackage`
   - Responsibility:
     - implement `org.moqui.impl.SystemMessageServices.send#SystemMessage`
     - parse `SystemMessage.messageText`
     - call D365 `ExportToPackage`
     - return `remoteMessageId = executionId`
 - **Generic poll service**
-  - Service: [D365DataPackageServices.poll#ExportDataPackageStatus](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:86)
+  - Service: `D365DataPackageServices.poll#ExportDataPackageStatus`
   - Responsibility:
     - find sent export messages by `systemMessageTypeId` and `statusId = SmsgSent`
     - call the single-message checker
 - **Generic single-message poll/check service**
-  - Service: [D365DataPackageServices.check#ExportDataPackageStatus](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:110)
+  - Service: `D365DataPackageServices.check#ExportDataPackageStatus`
   - Responsibility:
     - read `executionId` from `SystemMessage.remoteMessageId`
     - call `GetExecutionSummaryStatus`
@@ -139,12 +139,12 @@ This is the current export model and the implemented generic framework.
     - move the `SystemMessage` entity record to `SmsgConfirmed` on success
     - move it to `SmsgError` on terminal failure
 - **Generic download service**
-  - Service: [D365DataPackageServices.download#DataPackage](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:276)
+  - Service: `D365DataPackageServices.download#DataPackage`
   - Responsibility:
     - download the D365 ZIP
     - extract the configured file to a local directory
 - **Generic execution error reader**
-  - Service: [D365DataPackageServices.get#ExecutionErrors](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:385)
+  - Service: `D365DataPackageServices.get#ExecutionErrors`
   - Responsibility:
     - call D365 `GetExecutionErrors`
 
@@ -183,7 +183,7 @@ This is the current export model and the implemented generic framework.
   - D365 export failed, or OMS failed to process the returned file
 
 #### Boundary of the generic layer
-- The generic export services in [D365DataPackageServices.xml](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml) now cover:
+- The generic export services in `D365DataPackageServices.xml` now cover:
   - queuing export `SystemMessage` entity records
   - triggering D365 `ExportToPackage`
   - polling export status
@@ -209,7 +209,7 @@ This is the current export model and the implemented generic framework.
 
 - Use **Approach 2** for current and future export integrations.
 - Keep **Approach 1** documented only as the earlier design that validated the D365 export mechanics.
-- For the sales-order-specific export reconciliation flow that uses the current generic export services, refer to [implementation_plan.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md).
+- For the sales-order-specific export reconciliation flow that uses the current generic export services, refer to [implementation_plan.md](../sales-orders/implementation_plan.md).
 
 ---
 

--- a/project-ideas/dynamics365-integration/data-package-api/data_import_package_api.md
+++ b/project-ideas/dynamics365-integration/data-package-api/data_import_package_api.md
@@ -24,13 +24,13 @@ The Data Import Package API follows these core steps:
 The connector currently has the following generic implemented services over the D365 Data Package import APIs:
 
 - **Generic poll service for import execution**
-  - Service: [D365DataPackageServices.poll#ImportDataPackageStatus](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:348)
+  - Service: `D365DataPackageServices.poll#ImportDataPackageStatus`
   - Used by import polling service jobs to monitor D365 import execution ids stored as `SystemMessage` entity records
 - **Generic single-execution checker**
-  - Service: [D365DataPackageServices.check#ImportDataPackageStatus](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:384)
+  - Service: `D365DataPackageServices.check#ImportDataPackageStatus`
   - Checks one import execution id and updates the related `SystemMessage` entity record
 - **Generic execution error reader**
-  - Service: [D365DataPackageServices.get#ExecutionErrors](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:446)
+  - Service: `D365DataPackageServices.get#ExecutionErrors`
   - Retrieves D365 DMF execution errors for a given import execution id
   - Called by `check#ImportDataPackageStatus` when D365 reports a terminal failure status
 
@@ -56,9 +56,9 @@ The connector currently has the following generic implemented services over the 
 
 ### 4.3 Boundary of the Generic Layer
 
-- The generic services in [D365DataPackageServices.xml](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml) cover import-status polling and error retrieval after an import execution id already exists.
+- The generic services in `D365DataPackageServices.xml` cover import-status polling and error retrieval after an import execution id already exists.
 - Package construction, ZIP upload, `ImportFromPackage` submission, tracking-entity updates, and any follow-up reconciliation remain consumer-flow responsibilities.
-- For the sales-order-specific implementation that uses these generic APIs, refer to [implementation_plan.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md).
+- For the sales-order-specific implementation that uses these generic APIs, refer to [implementation_plan.md](../sales-orders/implementation_plan.md).
 
 ---
 

--- a/project-ideas/dynamics365-integration/products/d365_to_oms_product_sync_implementation_plan.md
+++ b/project-ideas/dynamics365-integration/products/d365_to_oms_product_sync_implementation_plan.md
@@ -13,8 +13,8 @@ The current connector work on products is an **export from D365 to OMS** using t
 ## 2. Current Scope
 
 ### 2.1 What is implemented
-- A D365 export `SystemMessage` flow using the generic export services in [D365DataPackageServices.xml](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml)
-- Product export job seeds in [D365ServiceJobData.xml](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/data/D365ServiceJobData.xml)
+- A D365 export `SystemMessage` flow using the generic export services in `D365DataPackageServices.xml`
+- Product export job seeds in `D365ServiceJobData.xml`
 - Download and extraction of `Released product variants V2.csv` into:
   - `runtime://datamanager/d365/export/products`
 
@@ -34,7 +34,7 @@ So the current product flow is best understood as:
 
 ## 3. Current Implemented Export Flow
 
-For the generic export framework, see [data_export_package_api.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/data-package-api/data_export_package_api.md).
+For the generic export framework, see [data_export_package_api.md](../data-package-api/data_export_package_api.md).
 
 The current product flow uses the generic export queue/send/poll services with product-specific job parameters.
 
@@ -46,8 +46,8 @@ The current product flow uses the generic export queue/send/poll services with p
 
 #### Queue Job
 - service job `d365_QueueProductVariantsExport`
-- defined in [D365ServiceJobData.xml](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/data/D365ServiceJobData.xml)
-- calls the generic service [D365DataPackageServices.queue#ExportDataPackage](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:4)
+- defined in `D365ServiceJobData.xml`
+- calls the generic service `D365DataPackageServices.queue#ExportDataPackage`
 
 Parameters:
 - `systemMessageTypeId = D365_EXPORT_PRODUCTS`
@@ -58,8 +58,8 @@ Parameters:
 
 #### Poll Job
 - service job `d365_ExportProductVariantsPoll`
-- defined in [D365ServiceJobData.xml](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/data/D365ServiceJobData.xml)
-- calls the generic service [D365DataPackageServices.poll#ExportDataPackageStatus](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/hotwax-d365/service/co/hotwax/d365/D365DataPackageServices.xml:86)
+- defined in `D365ServiceJobData.xml`
+- calls the generic service `D365DataPackageServices.poll#ExportDataPackageStatus`
 
 Parameter:
 - `systemMessageTypeId = D365_EXPORT_PRODUCTS`

--- a/project-ideas/dynamics365-integration/sales-orders/business_processes.md
+++ b/project-ideas/dynamics365-integration/sales-orders/business_processes.md
@@ -6,7 +6,7 @@ HotWax acts as an integration adapter to ensure that D365, as the financial syst
 
 ## 1. Foundational Concepts & System Setup
 
-The generic business-process foundations for D365 F&O integration are documented in [business_process_foundations.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/foundation/business_process_foundations.md).
+The generic business-process foundations for D365 F&O integration are documented in [business_process_foundations.md](../foundation/business_process_foundations.md).
 
 This sales-order document focuses only on customer, sales-order, and payment process behavior that is specific to the sales-order domain.
 
@@ -123,7 +123,7 @@ This pattern creates a composite package and submits it through the Data Managem
 | DMF | `Sales orders composite V4` | Composite import package | Batch/asynchronous | Package generation, upload, and import monitoring |
 
 > [!NOTE]
-> Detailed implementation specifics for both patterns are documented in [implementation_plan.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md) and the shared DMF reference at [data_import_package_api.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/data-package-api/data_import_package_api.md).
+> Detailed implementation specifics for both patterns are documented in [implementation_plan.md](implementation_plan.md) and the shared DMF reference at [data_import_package_api.md](../data-package-api/data_import_package_api.md).
 
 ### 3.3 Shared Business Rules
 

--- a/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
+++ b/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
@@ -3,7 +3,7 @@
 This document outlines the technical design and implementation steps for integrating HotWax OMS with Microsoft Dynamics 365 Finance & Operations (D365 F&O).
 
 ## 1. Technical Architecture
-- Sales-order integration uses the generic D365 connector foundation documented in [connector_foundation.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/foundation/connector_foundation.md).
+- Sales-order integration uses the generic D365 connector foundation documented in [connector_foundation.md](../foundation/connector_foundation.md).
 - **Sales-order specific interfaces**:
     - OData v4 (REST) for direct entity-based sync
     - Data Management Framework (DMF) / Data Package API for composite package import
@@ -78,7 +78,7 @@ This entity is used by the batch DMF import pattern (`import#SalesOrdersDataPack
 
 ## Foundation
 
-The generic connector foundation for authentication, credentials storage, legal-entity mapping, token management, and common OData request handling is documented in [connector_foundation.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/foundation/connector_foundation.md).
+The generic connector foundation for authentication, credentials storage, legal-entity mapping, token management, and common OData request handling is documented in [connector_foundation.md](../foundation/connector_foundation.md).
 
 This sales-order implementation plan focuses on the sales-order-specific services, entities, views, and orchestration built on top of that shared connector layer.
 
@@ -359,7 +359,7 @@ This section documents two approaches for the DMF / Data Package path:
 - **Approach 1**: execution tracking using `SystemMessage` records after the remote D365 trigger call
 - **Approach 2**: a Moqui-native `SystemMessage` send lifecycle using `SmsgProduced` -> `SmsgSending` -> `SmsgSent` -> `SmsgConfirmed`
 
-See the shared Data Package API reference: [data_import_package_api.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/data-package-api/data_import_package_api.md). That document describes only the generic D365 package API services; the sales-order-specific job, packaging, and submission details remain in this implementation plan.
+See the shared Data Package API reference: [data_import_package_api.md](../data-package-api/data_import_package_api.md). That document describes only the generic D365 package API services; the sales-order-specific job, packaging, and submission details remain in this implementation plan.
 
 ##### Approach 1 - Execution Tracking Using `SystemMessage` Records
 
@@ -706,7 +706,7 @@ After OMS confirms the remote execution and completes follow-up processing, the 
 - **Operational handling for now**: If a sales order import package fails, OMS records the failed state by moving the `SystemMessage` to `SmsgError`; the detailed import errors may need to be checked manually in D365 Data Management until API-based retrieval is figured out.
 - **TODO**: revisit failed sales order import error retrieval and confirm whether another D365 API, exported log, or DMF artifact can provide the detailed execution errors for composite entity imports.
 
-For generic package upload/import mechanics and API sequencing, refer to [data_import_package_api.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/data-package-api/data_import_package_api.md).
+For generic package upload/import mechanics and API sequencing, refer to [data_import_package_api.md](../data-package-api/data_import_package_api.md).
 
 ##### DMF TODOs / Gaps
 - Resolve `ITEMNUMBER` from OMS-to-D365 product mapping
@@ -742,7 +742,7 @@ This approach wraps the hierarchical `Sales orders composite V4` package and sen
    - **Binary Transmission Safety:** Uses standard Java `HttpURLConnection` to execute a direct binary `POST` payload transfer to the D365 Enqueuer endpoint (`/api/connector/enqueue/<activity-id>`) with `Content-Type: application/zip`, bypassing the Moqui `RestClient` limitation (which lacks binary-stream body method helpers).
    - Receives the D365 **Queue Message ID GUID** response, parses it cleanly to standard UTF-8 string format, deletes the temporary file from the disk to free up space, persists the Queue GUID directly to the `messageId` field in the database, returns it as `remoteMessageId` for initial status tracking, and moves the status to `SmsgSent`.
 
-3. **The Poller Orchestration (`pollAndConfirm#RecurringSalesOrderImport`):**
+3. **The Poller Orchestration (`poll#RecurringSalesOrderImport`):**
    - Regularly finds all `D365_REC_IMP_SLS_ORDERS` messages in the `SmsgSent` state.
    - Loops and triggers the custom status checker (`check#RecurringSalesOrderImport`) in individual transactions.
 
@@ -899,7 +899,7 @@ Add records to the entity `co.hotwax.integration.IntegrationTypeMapping` for the
 
 ### 2. Export of Sales Orders from D365 to OMS
 
-This flow returns the D365-generated `SalesOrderNumber` back into OMS after the OMS-to-D365 sales order import completes. The generic Data Package queue/send/poll services remain documented in [data_export_package_api.md](/Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/data-package-api/data_export_package_api.md); this section covers the sales-order-header-specific D365 project, jobs, row mappings, and OMS persistence.
+This flow returns the D365-generated `SalesOrderNumber` back into OMS after the OMS-to-D365 sales order import completes. The generic Data Package queue/send/poll services remain documented in [data_export_package_api.md](../data-package-api/data_export_package_api.md); this section covers the sales-order-header-specific D365 project, jobs, row mappings, and OMS persistence.
 
 #### Objective
 - Store the D365 `SalesOrderNumber` against the originating OMS order.

--- a/project-ideas/dynamics365-integration/sales-returns/business_processes.md
+++ b/project-ideas/dynamics365-integration/sales-returns/business_processes.md
@@ -63,7 +63,8 @@ The full step-by-step process for a physical return in D365:
 
 Before inventory can be received, arrival must be registered via an **Item Arrival Journal**.
 
-- Created via `ItemArrivalJournalHeadersV2` + `ItemArrivalJournalLinesV2` OData entities (confirmed available)
+- The OMS creates arrival journals via the D365 DMF **"Item arrival journals V2" composite entity** — header and lines are submitted as a single XML document in a ZIP package via `/api/connector/enqueue/{activityId}`; D365 auto-generates the journal number internally
+- The individual OData entities `ItemArrivalJournalHeadersV2` and `ItemArrivalJournalLinesV2` are confirmed available but are not used in the OMS integration — the OData path has a sequencing constraint where the journal number is auto-generated on header creation and must be known for each subsequent line POST; the DMF composite entity avoids this entirely
 - Posting the arrival journal is handled by the D365 batch class **`WMSJournalCheckPostReception`**
 - **Important limitation:** `WMSJournalCheckPostReception` posts **one selected journal at a time** — it is not a query-based batch that auto-picks up all unposted arrival journals. For bulk auto-posting, the class must be extended to multi-threaded behavior (like `LedgerJournalMultiPost`)
 - Quarantine can be enabled during arrival if inspection is required — quarantined items cannot have a disposition code assigned until the quarantine order is completed
@@ -153,8 +154,9 @@ Settlement matches the credit note (negative) and refund journal (positive) agai
 | :--- | :--- | :--- |
 | `ReturnOrderHeadersV2` | Create return order header | Step 1 |
 | `ReturnOrderLinesV2` | Create return order lines | Step 1 |
-| `ItemArrivalJournalHeadersV2` | Create arrival journal header | Step 2 |
-| `ItemArrivalJournalLinesV2` | Create arrival journal lines | Step 2 |
+| `ItemArrivalJournalHeadersV2` | Create arrival journal header | Step 2 — OData (not used in OMS integration; see DMF composite entity below) |
+| `ItemArrivalJournalLinesV2` | Create arrival journal lines | Step 2 — OData (not used in OMS integration; see DMF composite entity below) |
+| DMF: `Item arrival journals V2` | Create header + lines atomically | Step 2 — **Used in OMS integration**; submitted as ZIP via Queue Connector (`/api/connector/enqueue/{activityId}`) |
 | `CustomerPaymentJournalHeaders` | Create refund payment journal header | Step 7 |
 | `CustomerPaymentJournalLines` | Create refund payment journal lines | Step 7 |
 

--- a/project-ideas/dynamics365-integration/sales-returns/implementation_plan.md
+++ b/project-ideas/dynamics365-integration/sales-returns/implementation_plan.md
@@ -18,8 +18,13 @@ For D365 standard return process, disposition codes, accounting model, and lifec
 - ServiceJob-based batch sweep using `D365EligibleReturnView`
 - Retry for `D365_RTN_ERROR` and `D365_RTN_PARTIAL` records missed by event-driven Phase 1
 
+### Phase 3 — Arrival Journal DMF Sync (Implemented)
+- Batch-sweep ServiceJob packages eligible returns into a DMF ZIP using the "Item arrival journals V2" composite entity
+- Services: `queue#ArrivalJournals`, `send#ArrivalJournalImport`, `pollAndConfirm#ArrivalJournalImport`, `check#ArrivalJournalImport`
+- Tracking entity: `D365ArrivalJournalHistory`; view: `D365EligibleArrivalJournals`
+- `definitionGroupId`: `HotWax_Import_Item_Arrival_Journals_V2`
+
 ### Future Phases (Not yet in scope — see Section 7)
-- Arrival journal creation via OData
 - Arrival journal posting (D365 batch)
 - Packing slip posting (D365 batch)
 - Credit note generation
@@ -121,7 +126,7 @@ Tracks the aggregate sync state per return. PK is `returnId` (one row per OMS re
 | :--- | :--- | :--- |
 | `returnId` | id (PK) | OMS return ID |
 | `d365ReturnOrderNumber` | text-short | D365 `ReturnOrderNumber` from create response |
-| `d365RmaNumber` | text-short | D365 RMA number |
+| `d365RmaNumber` | text-short | D365 RMA number — captured from `RMANumber` in GET (`$select=ReturnOrderNumber,RMANumber`) and POST responses |
 | `syncStatusId` | id | `D365_RTN_PENDING` / `D365_RTN_SYNCED` / `D365_RTN_PARTIAL` / `D365_RTN_ERROR` |
 | `syncedDate` | date-time | Timestamp of successful sync |
 | `logText` | text-long | Error details |
@@ -306,7 +311,132 @@ Content-Type: application/json
 
 ---
 
-## 4. TODOs by Approach
+## 4. Phase 3 — Arrival Journal DMF Sync
+
+### 4.1 Approach: DMF Composite Entity over OData
+
+OData (`ItemArrivalJournalHeadersV2` + `ItemArrivalJournalLinesV2`) has a critical sequencing constraint: the arrival journal header must be POSTed first to obtain a D365-generated `JOURNALNUMBER`, which is then required for each line POST — the same N+1 problem encountered with return order lines. Except here, unlike return orders, there is no workaround via synchronous response chaining at scale.
+
+The DMF **"Item arrival journals V2" composite entity** solves this — header and lines are submitted as a single XML document in a ZIP package, and D365 resolves the journal number internally. This is the same pattern used for sales order sync via the `Sales orders V4` composite entity.
+
+Additionally, one ZIP can cover multiple return journals in a single import operation, making the sweep efficient.
+
+### 4.2 Data Model
+
+#### Entity: `D365ArrivalJournalHistory`
+
+Tracks which returns have been packaged into a DMF arrival journal import. A record means the return was included in at least one import attempt. There is no status field — presence equals queued.
+
+| Field | Type | Notes |
+| :--- | :--- | :--- |
+| `returnId` | id (PK) | OMS return ID |
+| `d365ReturnOrderNumber` | id | D365 `ReturnOrderNumber` at time of packaging |
+| `systemMessageId` | id | `SystemMessage` holding the DMF ZIP |
+| `queuedDate` | date-time | When the return was packaged |
+
+**Retry:** Delete the `D365ArrivalJournalHistory` record to re-queue. The `D365EligibleArrivalJournals` view excludes returns that have any history record.
+
+#### View-Entity: `D365EligibleArrivalJournals`
+
+Returns that are `D365_RTN_SYNCED` (return order exists in D365) and have no `D365ArrivalJournalHistory` record.
+
+Exposes: `returnId`, `destinationFacilityId`, `d365ReturnOrderNumber`, `d365RmaNumber`, `arrivalQueuedDate`.
+
+### 4.3 Service Architecture
+
+**File:** `co.hotwax.d365.D365ReturnServices`
+
+#### `queue#ArrivalJournals`
+
+Batch sweep — called by `queue_D365ArrivalJournals` ServiceJob.
+
+**Flow:**
+1. Query `D365EligibleArrivalJournals` (filtered by `returnId` for targeted runs)
+2. For each eligible return: fetch `ReturnHeader` + `ReturnItem` records
+3. Resolve customer account from `PartyIdentification(D365_CUST_ACCT)` on `ReturnHeader.fromPartyId` — no D365 call
+4. Resolve receiving site ID from parent facility's `externalId` (`Facility.parentFacilityId` → `siteFacility.externalId`)
+5. Resolve item numbers via `GoodIdentification(D365_PRODUCT_ID)` on `productId`
+6. Build `WMSITEMARRIVALJOURNALHEADERV2ENTITY` + `WMSITEMARRIVALJOURNALLINEV2ENTITY` XML per return journal
+7. Group all journals into one XML document, ZIP with `PackageHeader.xml` + `Manifest.xml`
+8. Create `SystemMessage(D365_ARR_JNL_IMPORT)` with the ZIP binary; create `D365ArrivalJournalHistory` per return
+
+Supports `dryRun=true` — logs generated XML without creating SystemMessage or history records.
+
+#### `send#ArrivalJournalImport`
+
+Implements `send#SystemMessage` for `SystemMessageTypeId=D365_ARR_JNL_IMPORT`. POSTs the ZIP to:
+```
+POST /api/connector/enqueue/{activityId}
+```
+D365 returns a Queue Message ID stored as the SystemMessage `remoteMessageId`.
+
+#### `pollAndConfirm#ArrivalJournalImport`
+
+ServiceJob-driven. Finds all `D365_ARR_JNL_IMPORT` SystemMessages in `SmsgSent` status and delegates to `check#ArrivalJournalImport` per message.
+
+#### `check#ArrivalJournalImport`
+
+1. Calls `GetExecutionIdByMessageId` with the Queue Message ID → resolves the DMF Execution ID
+2. Delegates to existing `check#ImportDataPackageStatus` with the Execution ID
+
+### 4.4 Field Mappings
+
+#### Arrival Journal Header (`WMSITEMARRIVALJOURNALHEADERV2ENTITY`)
+
+| XML Attribute | Source | Notes |
+| :--- | :--- | :--- |
+| `JOURNALNAMEID` | Hardcoded `WArr` | D365 warehouse arrival journal name |
+| `DEFAULTACCOUNTNUMBER` | `PartyIdentification(D365_CUST_ACCT)` on `ReturnHeader.fromPartyId` | No D365 call — resolved locally |
+| `DEFAULTRETURNITEMNUMBER` | `D365ReturnHeaderHistory.d365RmaNumber` | `RMANumber` from D365 (e.g. `00412`) |
+| `DEFAULTTRANSACTIONREFERENCENUMBER` | `D365ReturnHeaderHistory.d365ReturnOrderNumber` | `ReturnOrderNumber` from D365 (e.g. `001624`) |
+| `DEFAULTTRANSACTIONREFERENCETYPE` | Hardcoded `0` | Numeric — `0` = Sales order type |
+| `ISITEMMOVEDTODEFAULTITEMPICKINGWAREHOUSELOCATION` | Hardcoded `0` | Required on both header **and** line |
+
+#### Arrival Journal Lines (`WMSITEMARRIVALJOURNALLINEV2ENTITY`)
+
+| XML Attribute | Source | Notes |
+| :--- | :--- | :--- |
+| `LINENUMBER` | Sequential (1, 2, 3…) | Required — auto-incremented per journal |
+| `ACCOUNTNUMBER` | `PartyIdentification(D365_CUST_ACCT)` | Customer account |
+| `ITEMNUMBER` | `GoodIdentification(D365_PRODUCT_ID)` on `productId` | Falls back to `1000` — TODO |
+| `ITEMQUANTITY` | `ReturnItem.returnQuantity` | Positive quantity |
+| `ISRETURNORDER` | Hardcoded `1` | Marks as return arrival |
+| `RETURNITEMNUMBER` | `d365RmaNumber` | `RMANumber` (e.g. `00412`) |
+| `RETURNDISPOSITIONCODEID` | Hardcoded `11` | TODO: map from OMS return reason |
+| `TRANSACTIONREFERENCENUMBER` | `d365ReturnOrderNumber` | `ReturnOrderNumber` (e.g. `001624`) |
+| `TRANSACTIONREFERENCETYPE` | Hardcoded `0` | Numeric — `0` = Sales order type |
+| `TRANSACTIONDATE` | `ReturnHeader.entryDate` | Return entry date (not current timestamp) |
+| `ISITEMMOVEDTODEFAULTITEMPICKINGWAREHOUSELOCATION` | Hardcoded `0` | Required on both header and line |
+
+### 4.5 D365 Return Identifier Clarification
+
+Two distinct identifiers on a D365 return order:
+
+| D365 Field | Example | OMS Field | Arrival Journal Usage |
+| :--- | :--- | :--- | :--- |
+| `ReturnOrderNumber` | `001624` | `d365ReturnOrderNumber` | `DEFAULTTRANSACTIONREFERENCENUMBER` / `TRANSACTIONREFERENCENUMBER` |
+| `RMANumber` | `00412` | `d365RmaNumber` | `DEFAULTRETURNITEMNUMBER` / `RETURNITEMNUMBER` |
+
+`sync#ReturnOrder` captures both identifiers: GET uses `$select=ReturnOrderNumber,RMANumber`; POST response body contains both. Both are persisted to `D365ReturnHeaderHistory`.
+
+### 4.6 Customer Account Resolution
+
+`sync#Customer` now persists the resolved D365 customer account to `PartyIdentification(partyIdentificationTypeId='D365_CUST_ACCT')` after every successful sync (upsert by PK — safe on retry). The `queue#ArrivalJournals` service reads from this record locally when building the arrival journal XML — no additional D365 API call needed.
+
+`PartyIdentificationType(D365_CUST_ACCT)` seed data is defined in `D365OrderSyncData.xml`.
+
+### 4.7 ServiceJobs
+
+| Job | Service | Key Parameters |
+| :--- | :--- | :--- |
+| `queue_D365ArrivalJournals` | `queue#ArrivalJournals` | `systemMessageRemoteId`, `activityId` (D365 Data Management activity ID for "Item arrival journals V2"), `definitionGroupId=HotWax_Import_Item_Arrival_Journals_V2`, optional `returnId` |
+| `pollAndConfirm_D365ArrivalJournalImport` | `pollAndConfirm#ArrivalJournalImport` | `systemMessageRemoteId` |
+
+Both jobs are paused by default.
+
+---
+
+## 5. TODOs by Approach
 
 ### Phase 1 — OData Event-Driven (DataFeed) ✅ Core implemented and tested
 
@@ -326,11 +456,11 @@ Content-Type: application/json
 | 7 | Cron schedule | `sync_D365ReturnOrders` job has no cron set. Schedule once Phase 1 DataFeed path is validated in production. |
 | 8 | Full sweep test | Test `sync#ReturnOrders` with no `returnId` (sweep all eligible) to confirm batch isolation works — one failed return must not abort others. |
 
-### Future Phases — Downstream Lifecycle (see Section 6)
+### Future Phases — Downstream Lifecycle (see Section 7)
 
 | # | Item | Details |
 | :--- | :--- | :--- |
-| 9 | Arrival journal creation | For online returns — OMS signals goods received → `POST ItemArrivalJournalHeadersV2` + `POST ItemArrivalJournalLinesV2` |
+| 9 | Arrival journal creation via DMF | ✅ Implemented — `queue#ArrivalJournals` sweeps `D365EligibleArrivalJournals` and packages returns into a DMF ZIP using the "Item arrival journals V2" composite entity. See Section 4 for full details. |
 | 10 | Arrival journal posting | D365 batch class `WMSJournalCheckPostReception` — needs D365-side setup. Decide: OMS-triggered per journal or manual warehouse staff action. |
 | 11 | Credit note generation | D365 batch class `SalesFormLetter_Invoice` — runs after packing slip posted (or immediately for Credit only disposition). |
 | 12 | Credit note export back to OMS | Export generated credit note number back to OMS for reconciliation — similar to sales order number export. |
@@ -340,7 +470,7 @@ Content-Type: application/json
 
 ---
 
-## 5. Verification Plan
+## 6. Verification Plan
 
 | # | Step | Status |
 | :--- | :--- | :--- |
@@ -356,24 +486,32 @@ Content-Type: application/json
 | 10 | Test POS return — `RETURN_COMPLETED` on POS channel, confirm only `D365PosReturnHeaderDoc` fires | Pending — needs Shopify dev store |
 | 11 | Test `sync#ReturnOrders` sweep with no `returnId` — confirm batch isolation (one failure does not abort others) | Pending |
 | 12 | Test error scenario — unmapped product, confirm `D365_RTN_ERROR` on line, other lines continue | Pending |
+| 13 | Run `queue#ArrivalJournals` with `dryRun=true` — confirm generated XML shows `DEFAULTRETURNITEMNUMBER=RMANumber` (e.g. `00412`) and `DEFAULTTRANSACTIONREFERENCENUMBER=ReturnOrderNumber` (e.g. `001624`) | Pending |
+| 14 | Run `queue#ArrivalJournals` without `dryRun` — confirm `SystemMessage(D365_ARR_JNL_IMPORT)` created and `D365ArrivalJournalHistory` records inserted per return | Pending |
+| 15 | Run `send#ArrivalJournalImport` — confirm ZIP POSTed to `/api/connector/enqueue/{activityId}`, Queue Message ID persisted as `remoteMessageId` | Pending |
+| 16 | Run `pollAndConfirm#ArrivalJournalImport` — confirm DMF execution status resolved, SystemMessage marked confirmed | Pending |
+| 17 | Verify arrival journals visible in D365 `Inventory management > Journals > Item arrival` and can be posted | Pending |
 
 ---
 
-## 6. Future Phases — Downstream Lifecycle (Design Pending)
+## 7. Future Phases — Downstream Lifecycle
 
 The following steps complete the full return lifecycle in D365 after the return order is created. These are **not yet in scope** but are documented here for planning purposes based on research from Microsoft Learn and the D365 community thread.
 
-### Phase 3: Arrival Journal (Online Returns)
+### Phase 3: Arrival Journal DMF Sync ✅ Implemented
 
-**When:** OMS signals goods received (`RETURN_RECEIVED` or equivalent)
+**When:** `queue_D365ArrivalJournals` ServiceJob sweeps eligible returns after their return order is `D365_RTN_SYNCED`.
+
+OMS packages returns into a DMF ZIP using the "Item arrival journals V2" composite entity and submits via Queue Connector. See Section 4 for the full implementation details.
+
+**Remaining for Phase 3:**
 
 | Step | Detail |
 | :--- | :--- |
-| OMS creates arrival journal | `POST /data/ItemArrivalJournalHeadersV2` + `POST /data/ItemArrivalJournalLinesV2` |
 | D365 posts arrival journal | Batch class `WMSJournalCheckPostReception` — triggers per journal |
 | Limitation | Not a query-based auto-batch; one journal at a time; bulk posting requires extending the class to multi-threaded like `LedgerJournalMultiPost` |
 
-**Decision pending:** OMS-triggered vs. D365 warehouse staff manual for arrival registration.
+**Decision pending:** OMS-triggered vs. D365 warehouse staff manual for arrival journal posting.
 
 ### Phase 4: Credit Note Generation
 

--- a/project-ideas/dynamics365-integration/sales-returns/implementation_plan.md
+++ b/project-ideas/dynamics365-integration/sales-returns/implementation_plan.md
@@ -20,7 +20,7 @@ For D365 standard return process, disposition codes, accounting model, and lifec
 
 ### Phase 3 — Arrival Journal DMF Sync (Implemented)
 - Batch-sweep ServiceJob packages eligible returns into a DMF ZIP using the "Item arrival journals V2" composite entity
-- Services: `queue#ArrivalJournals`, `send#ArrivalJournalImport`, `pollAndConfirm#ArrivalJournalImport`, `check#ArrivalJournalImport`
+- Services: `queue#ArrivalJournals`, `send#ArrivalJournalImport`, `poll#ArrivalJournalImport`, `check#ArrivalJournalImport`
 - Tracking entity: `D365ArrivalJournalHistory`; view: `D365EligibleArrivalJournals`
 - `definitionGroupId`: `HotWax_Import_Item_Arrival_Journals_V2`
 
@@ -370,7 +370,7 @@ POST /api/connector/enqueue/{activityId}
 ```
 D365 returns a Queue Message ID stored as the SystemMessage `remoteMessageId`.
 
-#### `pollAndConfirm#ArrivalJournalImport`
+#### `poll#ArrivalJournalImport`
 
 ServiceJob-driven. Finds all `D365_ARR_JNL_IMPORT` SystemMessages in `SmsgSent` status and delegates to `check#ArrivalJournalImport` per message.
 
@@ -430,7 +430,7 @@ Two distinct identifiers on a D365 return order:
 | Job | Service | Key Parameters |
 | :--- | :--- | :--- |
 | `queue_D365ArrivalJournals` | `queue#ArrivalJournals` | `systemMessageRemoteId`, `activityId` (D365 Data Management activity ID for "Item arrival journals V2"), `definitionGroupId=HotWax_Import_Item_Arrival_Journals_V2`, optional `returnId` |
-| `pollAndConfirm_D365ArrivalJournalImport` | `pollAndConfirm#ArrivalJournalImport` | `systemMessageRemoteId` |
+| `poll_D365ArrivalJournalImport` | `poll#ArrivalJournalImport` | `systemMessageRemoteId` |
 
 Both jobs are paused by default.
 
@@ -489,7 +489,7 @@ Both jobs are paused by default.
 | 13 | Run `queue#ArrivalJournals` with `dryRun=true` — confirm generated XML shows `DEFAULTRETURNITEMNUMBER=RMANumber` (e.g. `00412`) and `DEFAULTTRANSACTIONREFERENCENUMBER=ReturnOrderNumber` (e.g. `001624`) | Pending |
 | 14 | Run `queue#ArrivalJournals` without `dryRun` — confirm `SystemMessage(D365_ARR_JNL_IMPORT)` created and `D365ArrivalJournalHistory` records inserted per return | Pending |
 | 15 | Run `send#ArrivalJournalImport` — confirm ZIP POSTed to `/api/connector/enqueue/{activityId}`, Queue Message ID persisted as `remoteMessageId` | Pending |
-| 16 | Run `pollAndConfirm#ArrivalJournalImport` — confirm DMF execution status resolved, SystemMessage marked confirmed | Pending |
+| 16 | Run `poll#ArrivalJournalImport` — confirm DMF execution status resolved, SystemMessage marked confirmed | Pending |
 | 17 | Verify arrival journals visible in D365 `Inventory management > Journals > Item arrival` and can be posted | Pending |
 
 ---


### PR DESCRIPTION
Adds Phase 3 (Arrival Journal DMF Sync) to the sales returns integration docs, covering the service architecture, DMF composite entity approach, field mappings, D365 identifier clarification (RMANumber vs ReturnOrderNumber), and customer account resolution via PartyIdentification.