### PR TITLE
docs: Improvements for D365 Integration documentation

### DIFF
--- a/project-ideas/dynamics365-integration/README.md
+++ b/project-ideas/dynamics365-integration/README.md
@@ -7,6 +7,14 @@ The goal of this integration is to synchronize critical business data, specifica
 
 ## Documentation Flow
 
+### Foundation
+1.  **[Business Process Foundations](foundation/business_process_foundations.md)**
+    *   Core D365 concepts that apply across all flows: multi-company structure (`dataAreaId`), the Party model, and number sequences.
+2.  **[Connector Foundation](foundation/connector_foundation.md)**
+    *   OMS-side connector patterns: credentials storage, OAuth token management, OData client, and metadata reference.
+3.  **[D365 SysOperation Framework](foundation/d365_sysoperation_framework.md)**
+    *   The Microsoft-standard three-class pattern (Contract / Service / Controller) used for all custom D365-side batch and periodic operations, with examples from this integration.
+
 ### Sales Orders
 1.  **[Business Processes](sales-orders/business_processes.md)**
     *   High-level business flows and requirements for Customer and Order management.

--- a/project-ideas/dynamics365-integration/data-package-api/data_export_package_api.md
+++ b/project-ideas/dynamics365-integration/data-package-api/data_export_package_api.md
@@ -45,7 +45,7 @@ Synchronizing Released Product Variants from D365 to Moqui/HotWax OMS.
 
 The connector has explored two integration approaches over the D365 Data Package Export APIs.
 
-### Approach 1 - Execution Tracking Using `SystemMessage` Records
+### 4.1 Approach 1 - Execution Tracking Using `SystemMessage` Records
 
 This was the earlier implementation approach.
 
@@ -94,7 +94,7 @@ This was the earlier implementation approach.
 - `sendNow=false` meant the created `SystemMessage` entity record was not intended to be sent through `send#ProducedSystemMessage`
 - `SmsgProduced` therefore represented a tracker row, not a true produced outbound message
 
-### Approach 2 - Moqui-Native `SystemMessage` Send Flow
+### 4.2 Approach 2 - Moqui-Native `SystemMessage` Send Flow
 
 This is the current export model and the implemented generic framework.
 
@@ -198,23 +198,25 @@ This is the current export model and the implemented generic framework.
   - `dataManagerConfigId` or `targetDirectory`
 - Consumer flows also provide the downstream row-processing logic through the configured DataManager import service.
 
-### 4.1 Implemented Export APIs Used
+### 4.3 Implemented Export APIs Used
 
 - `ExportToPackage` API
 - `GetExecutionSummaryStatus` API
 - `GetExportedPackageUrl` API
 - `GetExecutionErrors` API
 
-### 4.2 Guidance for Consumer Flows
+### 4.4 Guidance for Consumer Flows
 
 - Use **Approach 2** for current and future export integrations.
 - Keep **Approach 1** documented only as the earlier design that validated the D365 export mechanics.
 - For the sales-order-specific export reconciliation flow that uses the current generic export services, refer to [implementation_plan.md](../sales-orders/implementation_plan.md).
 
+
 ---
 
 ## 5. Key Considerations
+*   **Data Project Must Exist**: The export data project (`definitionGroupId`) must already be created in D365 Data Management before calling `ExportToPackage`. If the project does not exist, the API call will return an error.
 *   **Asynchronous Nature**: Exports are batch jobs in D365 and may take several minutes depending on the volume of data.
 *   **Unique Package Names**: Always generate a unique `packageName` for each export to avoid collisions.
 *   **File Encoding**: D365 typically exports CSVs in `UTF-16LE` encoding. Local processing logic must be aware of this.
-*   **Security**: The download URL is a pre-signed SAS token and typically expires within 90 minutes.
+*   **File Retention**: The exported file in Azure Blob storage is available for **seven days** after which it is automatically deleted by D365. Download and process the package within this window.

--- a/project-ideas/dynamics365-integration/data-package-api/data_import_package_api.md
+++ b/project-ideas/dynamics365-integration/data-package-api/data_import_package_api.md
@@ -12,14 +12,14 @@ The Data Import Package API follows these core steps:
 1.  **Generate Data**: Create the data files (CSV or XML) containing the records to import.
 2.  **Generate Manifest**: Create a `Manifest.xml` and `PackageHeader.xml` that define the entities and their processing order.
 3.  **Create ZIP**: Bundle the data files and manifests into a single ZIP package.
-4.  **Get Upload URL**: Call the OData Action `GetAzureWriteUrl` to obtain a temporary Azure Blob storage URL and a `BlobId`.
-5.  **Upload**: Execute an HTTP PUT to upload the ZIP file to the Azure URL.
-6.  **Trigger Import**: Call the OData Action `ImportFromPackage`, passing the `BlobId` and a `DefinitionGroupId` (the DMF project name in D365).
+4.  **Get Upload URL**: Call the OData Action `GetAzureWriteUrl` to obtain a temporary Azure Blob storage `BlobUrl` (the PUT target) and a `BlobId` (a separate identifier not used in the import call).
+5.  **Upload**: Execute an HTTP PUT to upload the ZIP file to the `BlobUrl`.
+6.  **Trigger Import**: Call the OData Action `ImportFromPackage`, passing `packageUrl` (the `BlobUrl` from Step 4) and a `DefinitionGroupId` (the DMF project name in D365).
 7.  **Monitor (Optional)**: Use `GetExecutionSummaryStatus` to poll for completion.
 
 ---
 
-## 4. Implemented Services Over D365 Data Package Import APIs
+## 3. Implemented Services Over D365 Data Package Import APIs
 
 The connector currently has the following generic implemented services over the D365 Data Package import APIs:
 
@@ -34,14 +34,14 @@ The connector currently has the following generic implemented services over the 
   - Retrieves D365 DMF execution errors for a given import execution id
   - Called by `check#ImportDataPackageStatus` when D365 reports a terminal failure status
 
-### 4.1 Import APIs Used
+### 3.1 Import APIs Used
 
 - `GetAzureWriteUrl` API
 - `ImportFromPackage` API
 - `GetExecutionSummaryStatus` API
 - `GetExecutionErrors` API
 
-### 4.2 Import Tracking and Failure Handling
+### 3.2 Import Tracking and Failure Handling
 
 - After D365 accepts an import package and returns an execution id, the producer flow creates a `SystemMessage` tracking row in `SmsgSent` and stores the D365 execution id in `SystemMessage.remoteMessageId`.
 - Import status jobs should call `D365DataPackageServices.poll#ImportDataPackageStatus` with the stream-specific `systemMessageTypeId`, and may override `retryMinutes` and `limit` from the service job.
@@ -49,19 +49,24 @@ The connector currently has the following generic implemented services over the 
 - Each execution is checked in its own transaction using `transaction="force-new" ignore-error="true"` so one failed D365 status check does not block the rest of the batch.
 - The checker updates `lastAttemptDate`, calls D365 `GetExecutionSummaryStatus` using the execution id stored in `SystemMessage.remoteMessageId`, and:
   - moves the message to `SmsgConfirmed` when D365 returns `Succeeded` or `PartiallySucceeded`
-  - calls `D365DataPackageServices.get#ExecutionErrors` and moves the message to `SmsgError` when D365 returns `Failed`, `Unknown`, or `Canceled`
+  - calls `D365DataPackageServices.get#ExecutionErrors` and moves the message to `SmsgError` when D365 returns `Failed`, `Unknown`, or `Canceled`. Note: `Unknown` is not explicitly defined as a terminal state in Microsoft's documentation — it is treated as terminal here to avoid indefinite retries, but this could theoretically fail a message that would eventually resolve.
+- **Composite entity requirement**: When the package contains a composite entity, the `overwrite` parameter in the `ImportFromPackage` call **must be set to `false`**. Microsoft explicitly documents this constraint — setting `overwrite=true` with a composite entity causes import failures.
+
+  > [!WARNING]
+  > The current `hotwax-d365` implementation sets `overwrite: true` in all `ImportFromPackage` calls, including the `Sales orders composite V4` import in `D365OrderServices.xml` (line ~585). This is inconsistent with Microsoft's documented requirement for composite entities and may be contributing to the silent `Failed` status observed on composite imports. **TODO:** Investigate and change `overwrite: true` → `overwrite: false` for all composite entity imports and verify whether this resolves the failure.
 - Known D365 limitation observed with composite entity imports: for the Sales Orders Data Package import using `Sales orders composite V4`, D365 returns `Failed` from `GetExecutionSummaryStatus`, but `GetExecutionErrors` does not return the detailed execution errors through the API.
 - Until this is resolved, failed composite imports may need to be reviewed manually in D365 Data Management.
 - **TODO**: revisit error retrieval for failed composite imports and identify an API or exportable log source that returns detailed D365 execution errors.
 
-### 4.3 Boundary of the Generic Layer
+### 3.3 Boundary of the Generic Layer
 
 - The generic services in `D365DataPackageServices.xml` cover import-status polling and error retrieval after an import execution id already exists.
 - Package construction, ZIP upload, `ImportFromPackage` submission, tracking-entity updates, and any follow-up reconciliation remain consumer-flow responsibilities.
 - For the sales-order-specific implementation that uses these generic APIs, refer to [implementation_plan.md](../sales-orders/implementation_plan.md).
 
+
 ---
 
 ## 5. Prerequisites
 *   **Permissions**: The App Registration requires Data Management privileges in D365 (**System administration > Setup > Microsoft Entra ID applications**).
-*   **Roles**: Assign the **Data management administrator** role or a custom role with DMF access to the integration user.
+*   **Roles**: Assign a role with DMF access to the integration user (e.g. **Data management administrator**, or a custom role granting Data Management privileges). Microsoft's official docs do not prescribe a specific role name — validate the required role against your D365 environment's security configuration.

--- a/project-ideas/dynamics365-integration/data-package-api/data_project_field_mapping_update.md
+++ b/project-ideas/dynamics365-integration/data-package-api/data_project_field_mapping_update.md
@@ -37,14 +37,14 @@ This means you cannot simply add a manual mapping for a new field — the Source
 
 7. Inside the project, find the entity tile (e.g., `Sales order lines V3`) and click **View map**.
 
-8. Click **Regenerate source mapping** (or **Generate source mapping** depending on the D365 version).
+8. Click **Regenerate source mapping** (the button reads **Generate source mapping** on a first-time setup when no mapping exists yet; for an existing project being updated, it will always read **Regenerate source mapping**).
    - D365 will ask: *"Do you want to generate the mapping from scratch?"* → click **Yes**.
    - The new field now appears in the Source field column and is automatically mapped to the matching Staging field.
 
 9. **Verify** that the new field appears in the mapping with a Source → Staging connection.
 
 > [!NOTE]
-> `Load project` + `Upload file` is the correct entry point for replacing the sample file on an existing project. Opening the project directly and using `Add file` or `Run project` serves a different purpose and may not correctly replace the existing entity's source file.
+> `Run project` (from the project list action bar, without opening the project) is the correct entry point for replacing the sample file. It exposes the `Upload file` option that replaces the existing entity's source file. Do not open the project directly to upload — use the action bar.
 
 ## Example: Adding `HCFULFILLMENTTYPE` to `HotWax_Import_Brokered_Order_Items`
 
@@ -62,3 +62,10 @@ After regenerating the source mapping, the mapping should show:
 | INVENTORYLOTID | INVENTORYLOTID |
 | SHIPPINGWAREHOUSEID | SHIPPINGWAREHOUSEID |
 | HCFULFILLMENTTYPE | HCFULFILLMENTTYPE |
+
+---
+
+## Related Docs
+
+- [data_import_package_api.md](./data_import_package_api.md) — Import package API flow that uses these data projects for inbound sync.
+- [data_export_package_api.md](./data_export_package_api.md) — Export package API flow that uses these data projects for outbound sync.

--- a/project-ideas/dynamics365-integration/foundation/business_process_foundations.md
+++ b/project-ideas/dynamics365-integration/foundation/business_process_foundations.md
@@ -8,7 +8,7 @@ Before records can be synchronized, the foundational structural context must be 
 
 ### 1.1 Multi-Company Structure (dataAreaId) & Legal Entities
 - **dataAreaId**: Represents the Legal Entity (Company).
-- **System Bucket**: Every table in D365 is partitioned by this "Company Code." It defines the context for all validation and financial posting.
+- **System Bucket**: Most transactional and configuration tables in D365 are partitioned by this "Company Code." It defines the context for all validation and financial posting. Shared tables (such as products, workers, and chart of accounts) are global and do not carry a `dataAreaId`.
 - **Organization Administration**: Legal entities are managed under the Organization Administration module.
 - **Validation**: Fields like Customer group, currency, and posting profiles are validated within the specific company context.
 
@@ -22,7 +22,7 @@ Before records can be synchronized, the foundational structural context must be 
 ### 1.3 Number Sequences & Identification
 Number sequences are used in D365 to generate unique identifiers for entities like Customers and Sales Orders. The generation of identifiers such as `CustomerAccount` is company-specific and controlled by D365 configuration.
 
-- **Reference**: [Number sequences overview](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/fin-ops/organization-administration/number-sequence-overview?toc=%2Fdynamics365%2Fretail%2Ftoc.json)
+- **Reference**: [Number sequences overview](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/fin-ops/organization-administration/number-sequence-overview)
 
 #### 1.3.1 Verifying Configuration
 To check the sequence in a specific legal entity (for example `USMF`):
@@ -41,7 +41,7 @@ The **Manual** flag directly affects API behavior during record creation:
 | Manual Setting | API Behavior |
 | :--- | :--- |
 | **Yes** | Identifier must be provided in the payload. |
-| **No** | Identifier is auto-generated; caller-provided values are ignored or rejected. |
+| **No** | Identifier is auto-generated; caller-provided values are ignored or rejected. D365 returns the generated identifier in the API response body — integrations must read it from the response to capture the D365-assigned ID. |
 
 > [!IMPORTANT]
 > If `Manual = Yes` and the identifier is missing, the API rejects the request.
@@ -57,3 +57,9 @@ For a system-of-record style integration, the preferred configuration is:
 > The current connector implementations may still assume caller-provided identifiers in some flows during exploration and early rollout.
 >
 > **TODO:** Re-evaluate each flow if the target D365 environments move to auto-generated numbering.
+
+---
+
+## Related Docs
+
+- [connector_foundation.md](./connector_foundation.md) — Generic connector-level modeling: credentials, token management, OData client, and metadata reference.

--- a/project-ideas/dynamics365-integration/foundation/business_process_foundations.md
+++ b/project-ideas/dynamics365-integration/foundation/business_process_foundations.md
@@ -63,3 +63,4 @@ For a system-of-record style integration, the preferred configuration is:
 ## Related Docs
 
 - [connector_foundation.md](./connector_foundation.md) — Generic connector-level modeling: credentials, token management, OData client, and metadata reference.
+- [d365_sysoperation_framework.md](./d365_sysoperation_framework.md) — The D365-side X++ batch operation pattern (SysOperation Framework) used for all custom periodic jobs in this integration.

--- a/project-ideas/dynamics365-integration/foundation/connector_foundation.md
+++ b/project-ideas/dynamics365-integration/foundation/connector_foundation.md
@@ -72,3 +72,4 @@ This document captures the generic connector-level modeling used across the `hot
 ## Related Docs
 
 - [business_process_foundations.md](./business_process_foundations.md) — Foundational D365 concepts: multi-company structure, the Party model, and number sequences.
+- [d365_sysoperation_framework.md](./d365_sysoperation_framework.md) — The D365-side X++ batch operation pattern (SysOperation Framework) used for all custom periodic jobs in this integration.

--- a/project-ideas/dynamics365-integration/foundation/connector_foundation.md
+++ b/project-ideas/dynamics365-integration/foundation/connector_foundation.md
@@ -6,7 +6,7 @@ This document captures the generic connector-level modeling used across the `hot
 - **Protocols / Interfaces**:
   - OData v4 (REST) for direct entity-based sync
   - Data Management Framework (DMF) / Data Package APIs for package import/export
-- **Authentication**: OAuth 2.0 Client Credentials Flow via Azure AD
+- **Authentication**: OAuth 2.0 Client Credentials Flow via Microsoft Entra ID
 - **Mapping Strategy**:
   - **Legal Entity Mapping**: Moqui `ProductStore` / `Organization` -> D365 `dataAreaId`
   - **Logic**: Every request must explicitly include the mapped `dataAreaId`
@@ -18,7 +18,7 @@ This document captures the generic connector-level modeling used across the `hot
 - Suggested fields:
   - `username` for Azure client id
   - `password` for Azure client secret
-  - `sendUrl` for Azure token endpoint (tenant-specific)
+  - `sendUrl` for Azure token endpoint (tenant-specific, v2.0 format: `https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token`)
   - `receiveUrl` for D365 instance base URL
   - `systemMessageRemoteId` as the connector key (for example `D365_HotWax_Dev`)
   - `description` for environment context
@@ -31,10 +31,12 @@ This document captures the generic connector-level modeling used across the `hot
   "sendUrl": "https://login.microsoftonline.com/YOUR_TENANT_ID/oauth2/v2.0/token",
   "receiveUrl": "YOUR_D365_INSTANCE_URL",
   "description": "Dynamics 365 Finance & Operations Remote for HotWax Dev Environment",
-  "_entity": "moqui.service.message.SystemMessageRemote",
-  "lastUpdatedStamp": "2026-03-12T09:15:41+0000"
+  "_entity": "moqui.service.message.SystemMessageRemote"
 }
 ```
+
+> [!IMPORTANT]
+> The v2.0 token endpoint requires a `scope` parameter in the token request body with the value `https://YOUR_D365_INSTANCE_URL/.default` (e.g. `https://usncax1aos.cloud.onebox.dynamics.com/.default`). The v1.0 endpoint (`/oauth2/token`) uses a `resource` parameter instead. Ensure the `get#AzureAccessToken` service passes the correct parameter for whichever endpoint version is configured in `sendUrl`.
 
 ### 2.2 Legal Entity Mapping
 - Use `ProductStore.externalId` to store the mapping from Moqui `ProductStore` to D365 `dataAreaId`.
@@ -51,7 +53,9 @@ This document captures the generic connector-level modeling used across the `hot
 - Service responsibilities:
   - inject the access token
   - resolve the D365 base URL
-  - include the `dataAreaId` context
+  - include the `dataAreaId` context — the mechanism differs by operation type:
+    - **Reads (GET)**: OData returns only the service user's default company by default. To query a specific non-default company, append `?cross-company=true&$filter=dataAreaId eq 'XXXX'` to the request.
+    - **Writes (POST/PATCH)**: Set the `dataAreaId` field directly in the entity payload. D365 handles the company context switch automatically.
   - centralize common OData request handling
 
 ## 3. Technical Reference: OData Metadata
@@ -61,4 +65,10 @@ This document captures the generic connector-level modeling used across the `hot
 | **EntitySet** | The URL collection or endpoint, for example `CustomersV3`. |
 | **EntityType** | The schema definition and structure of the data object. |
 | **Key** | The primary key fields. |
-| **Nullable=\"false\"** | A required field that cannot be empty. |
+| **Nullable=\"false\"** | The field cannot be null. Note: this does not prevent an empty string — additional business-level validation may still be required. |
+
+---
+
+## Related Docs
+
+- [business_process_foundations.md](./business_process_foundations.md) — Foundational D365 concepts: multi-company structure, the Party model, and number sequences.

--- a/project-ideas/dynamics365-integration/foundation/d365_sysoperation_framework.md
+++ b/project-ideas/dynamics365-integration/foundation/d365_sysoperation_framework.md
@@ -1,0 +1,67 @@
+# D365 SysOperation Framework
+
+This document explains the SysOperation Framework — the Microsoft-standard pattern used to build all custom D365-side batch and periodic operations in this integration.
+
+- **Official Reference**: [SysOperation Framework Overview](https://learn.microsoft.com/en-us/dynamicsax-2012/developer/sysoperation-framework-overview)
+
+---
+
+## What It Is
+
+The SysOperation Framework is Microsoft's recommended approach for creating batch and periodic operations in D365 F&O. It replaced the older `RunBase` framework and is the standard pattern across both standard D365 application code and custom extensions.
+
+It is used whenever a D365-side operation needs to:
+- Accept user-configurable parameters
+- Run interactively (with a dialog) or as a scheduled batch job without code changes
+- Process records in bulk with transaction safety and error reporting
+
+---
+
+## The Three-Class Structure
+
+Every SysOperation operation is built from three classes with clearly separated responsibilities.
+
+### Contract (`@DataContractAttribute`)
+
+The serializable parameter bag. Each field is annotated with `@DataMemberAttribute`, which tells the framework to include it in the dialog and serialize it for batch transport.
+
+Two things follow from this:
+- **The dialog is auto-generated** — D365 builds the user input dialog directly from the contract fields. No separate UI code is needed.
+- **Parameters must be serializable** — because when a job is sent to the batch server, the contract is serialized and reconstructed on a different thread. Primitive types (`int`, `str`, `boolean`) and D365 extended data types satisfy this automatically.
+
+### Service
+
+A plain X++ class containing the business logic. It receives the contract as a method parameter and does the work. There is no required base class — it is just a regular class.
+
+Because the service has no framework coupling, it can be:
+- Called directly from other X++ code without going through a dialog
+- Tested in isolation
+- Replaced or extended without touching the controller or contract
+
+### Controller (`SysOperationServiceController`)
+
+The orchestrator. It extends `SysOperationServiceController` and in its constructor declares which service class and method to call. It handles:
+- Displaying the dialog to the user
+- Setting execution mode: `Synchronous` (runs immediately, blocking) or `Asynchronous` / `Scheduled` (routes to the batch server)
+- The `main(Args _args)` static method, which is what menu items and batch job configurations call as the entry point
+
+---
+
+## Implemented Operations in This Integration
+
+| Operation | Service Class | Default Parameters | What it does |
+| :--- | :--- | :--- | :--- |
+| Auto-post arrival journals | `HotWaxAutoPostArrivalJournalService` | `JournalNameId = RTN_ARR`, `MaxJournals = 50` | Queries unposted Reception (`WMSJournalType::Reception`) journals matching the configured journal name and posts each one using `WMSJournalCheckPostReception`. Commits per journal; reports total success and failure counts. |
+| Auto-post settlement | `HotWaxAutoPostSettlementService` | — | Matches and settles posted customer payments against posted invoices using `SalesOrderNumber` as the key (via `PaymReference = SalesId`). Implements the custom settlement logic required because D365 OOTB settlement uses FIFO by customer and ignores the payment reference field. |
+| Test payment journal | `HotWaxTestPaymentJournalService` | — | Test and debug utility for customer payment journal posting. Not used in production flows. |
+
+> [!NOTE]
+> All three operations are accessible from **System Administration → Periodic** in the D365 UI, registered via the `SystemAdministration.HotWaxD365Integration.xml` menu extension.
+
+---
+
+## Related Docs
+
+- [connector_foundation.md](./connector_foundation.md) — OMS-side connector patterns: credentials, token management, and OData client.
+- [business_process_foundations.md](./business_process_foundations.md) — D365 foundational concepts: multi-company structure, the Party model, and number sequences.
+- [dynamics365-integration architecture.md](../../../../dynamics365-integration/docs/architecture.md) — High-level overview of all D365-side architectural patterns including model isolation and OData entity usage.

--- a/project-ideas/dynamics365-integration/recurring-integrations/recurring_integrations_api.md
+++ b/project-ideas/dynamics365-integration/recurring-integrations/recurring_integrations_api.md
@@ -13,7 +13,7 @@ The Inbound Integration allows external systems to push bulk data files or compo
 ### 1.1 Core Enqueue API
 External systems push payloads directly into a scheduled data job queue:
 * **Endpoint:** `POST https://<d365-instance-url>/api/connector/enqueue/<activity-id>`
-* **Content-Type:** `application/zip` (for Data Packages) or `application/octet-stream` (for flat files like CSV).
+* **Content-Type:** `application/zip` for a Data Package ZIP — which is what the `hotwax-d365` connector sends (confirmed in implementation). `application/octet-stream` (generic binary) is also accepted by the API for any binary payload, whether a ZIP package or a standalone flat file (CSV/XML). Microsoft's documentation does not specify which value to use; the API accepts both.
 * **Response (HTTP 200):** Returns a unique **Queue Message ID** GUID in the JSON body:
   ```json
   {
@@ -21,11 +21,18 @@ External systems push payloads directly into a scheduled data job queue:
   }
   ```
 
+> **`?entity=<entity name>` query parameter** — This parameter is optional, and its requirement depends on the data project configuration:
+> - **Single-entity project:** Can be omitted. D365 routes the payload to the only entity configured in the activity.
+> - **Multi-entity project + individual file (CSV/XML):** Must be specified. Without it, D365 cannot determine which entity the file belongs to and the import will fail.
+> - **Multi-entity project + Data Package ZIP (with `PackageHeader.xml`):** Can be omitted. The package manifest carries the entity mapping internally.
+>
+> The `hotwax-d365` connector sends Data Packages with `PackageHeader.xml`, so the parameter is omitted in all current enqueue calls.
+
 ### 1.2 Programmatic Error Retrieval Strategy
 Both standard Data Package (`ImportFromPackage`) and queue-based Recurring Integrations use the same underlying D365 Data Management Framework (DMF) engine. When an import fails, F&O exposes detailed record-level errors through the following two-step sequencing:
 
 #### Step 1: Resolve the Execution ID from the Message ID
-Because enqueuing returns a *Queue Message ID* (rather than a DMF *Execution ID*), we first call the OData action:
+Because enqueuing returns a *Queue Message ID* (rather than a DMF *Execution ID*), we first call the custom service endpoint:
 * **Endpoint:** `POST /data/DataManagementDefinitionGroups/Microsoft.Dynamics.DataEntities.GetExecutionIdByMessageId`
 * **Request Body:**
   ```json
@@ -34,12 +41,41 @@ Because enqueuing returns a *Queue Message ID* (rather than a DMF *Execution ID*
   }
   ```
 * **Response:** Returns the underlying DMF `executionId` GUID.
-  * > [!IMPORTANT]
-  * > **Handling Pending Queue Messages (Empty GUID):** If the Dynamics 365 background batch engine has not yet scheduled the enqueued file, the API returns the empty GUID `00000000-0000-0000-0000-000000000000`.
-  * >
-  * > In our poller poller (`check#RecurringSalesOrderImport`), this fallback GUID is intercepted, logging that the message is still pending in the queue, updating `lastAttemptDate` to throttle OData rate consumption, and keeping the message in the `SmsgSent` state for retry in the next scheduled loop.
-  * >
-  * > Once a valid non-zero DMF `executionId` is returned, the poller dynamically writes the `executionId` into `remoteMessageId` while keeping the original Queue Message ID safely preserved in the `messageId` field. This enables Moqui to maintain full auditability of both the Queue Message ID and the underlying DMF Execution ID concurrently.
+
+  > [!IMPORTANT]
+  > **Handling Pending Queue Messages (Empty GUID):** If the Dynamics 365 background batch engine has not yet scheduled the enqueued file, the API returns the empty GUID `00000000-0000-0000-0000-000000000000`.
+  >
+  > In our poller (`check#RecurringSalesOrderImport`), this fallback GUID is intercepted, logging that the message is still pending in the queue, updating `lastAttemptDate` to throttle OData rate consumption, and keeping the message in the `SmsgSent` state for retry in the next scheduled loop.
+  >
+  > Once a valid non-zero DMF `executionId` is returned, the poller dynamically writes the `executionId` into `remoteMessageId` while keeping the original Queue Message ID safely preserved in the `messageId` field. This enables Moqui to maintain full auditability of both the Queue Message ID and the underlying DMF Execution ID concurrently.
+
+#### Alternative: GetMessageStatus
+The Microsoft docs also describe a `GetMessageStatus` API that returns the queue-level processing state of a message directly from its Queue Message ID:
+
+* **Endpoint:** `POST /data/DataManagementDefinitionGroups/Microsoft.Dynamics.DataEntities.GetMessageStatus`
+* **Request Body:** `{ "messageId": "<queue-message-guid>" }`
+* **Response:** Returns one of the following status values:
+
+| Status | Meaning |
+| :--- | :--- |
+| `Enqueued` | File successfully enqueued to blob storage |
+| `Dequeued` | File successfully dequeued from blob storage |
+| `Acked` | Exported file acknowledged as downloaded |
+| `Preprocessing` | Import/export operation is preprocessing the request |
+| `Processing` | Import/export operation is in progress |
+| `Processed` | Import/export operation completed successfully |
+| `PreProcessingError` | Operation failed in the preprocessing stage |
+| `ProcessedWithErrors` | Operation completed with errors |
+| `PostProcessingFailed` | Operation failed during post-processing |
+
+**Why the current implementation uses `GetExecutionIdByMessageId` instead:**
+`GetMessageStatus` only returns a queue-level status string — it does not return the DMF Execution ID. Since `GetExecutionSummaryStatus` and `GetExecutionErrors` both require the Execution ID, `GetExecutionIdByMessageId` is called directly. Its non-zero response confirms processing started and provides the Execution ID in one call, making `GetMessageStatus` redundant in the current flow.
+
+**Known gap:** If a message hits a `PreProcessingError`, `GetExecutionIdByMessageId` returns the zero GUID indefinitely — the poller keeps retrying without knowing the message actually failed. Calling `GetMessageStatus` first could detect this state early and move the `SystemMessage` to a failed status without waiting for a timeout.
+
+> **TODO:** Evaluate adding a `GetMessageStatus` call in `check#RecurringSalesOrderImport` before `GetExecutionIdByMessageId` to detect `PreProcessingError` early and avoid indefinite polling on permanently failed messages.
+
+---
 
 #### Step 2: Retrieve the Staging Execution Errors
 Once the `executionId` is resolved, we call the standard error reader endpoint:
@@ -62,15 +98,15 @@ This allows Moqui to capture, decode, and log the F&O validation failures direct
 ### 1.3 DMF Staging Error Pipeline Scenarios & Visibility
 While programmatic retrieval is highly robust, calling `GetExecutionErrors` will return different results depending strictly on the **point of failure** inside the F&O execution pipeline:
 
+* **Phase 0: Import Engine Package & Schema Mismatches (Returns Empty)**
+  - *Scenario:* The XML payload is malformed or completely omits a mapped element (e.g. commenting out the `SHIPPINGWAREHOUSEID` element when it has a defined column mapping in the data project).
+  - *Result:* The D365 Import Engine throws a mapping collection crash (`HRESULT: 0xC0010009`) and aborts immediately before writing *any* rows to the staging tables. Since F&O never created staging records, **no staging error logs exist**, and `GetExecutionErrors` **returns an empty list**.
 * **Phase 1: File/Source $\rightarrow$ Staging Table (Fully Exposed)**
   - *Scenario:* The package is correctly formed, but the data fails staging validations (e.g. `PRODUCTCOLORID` value is invalid, or the customer profile does not exist in F&O).
   - *Result:* The D365 Import Engine successfully writes rows to the staging tables and records the validation constraints in the staging logs. `GetExecutionErrors` **successfully returns** the complete JSON list of failures.
 * **Phase 2: Staging $\rightarrow$ Target Ledger Tables (Conditional Exposure)**
   - *Scenario:* The records pass staging checks but crash on ledger-specific target business logic (e.g., credit limit exceeded or posting period closed).
   - *Result:* If the target writing logic propagates errors back to the staging tables, they are visible. If they reside exclusively in F&O's global System InfoLogs, `GetExecutionErrors` might return an empty list.
-* **Phase 0: Import Engine Package & Schema Mismatches (Returns Empty)**
-  - *Scenario:* The XML payload is malformed or completely omits a mapped element (e.g. commenting out the `SHIPPINGWAREHOUSEID` element when it has a defined column mapping in the data project).
-  - *Result:* The D365 Import Engine throws a mapping collection crash (`HRESULT: 0xC0010009`) and aborts immediately before writing *any* rows to the staging tables. Since F&O never created staging records, **no staging error logs exist**, and `GetExecutionErrors` **returns an empty list**.
 * **Staging Data Clean-up Purge Rules (Returns Empty)**
   - *Scenario:* D365 standard periodic jobs run "Staging clean-up" batches to physically purge staging rows and their logs to avoid database bloat.
   - *Result:* Once old staging logs are cleaned up, calling `GetExecutionErrors` for historical executions **returns an empty list**.
@@ -84,7 +120,7 @@ The Outbound Integration allows external systems to pull bulk data files generat
 ### 2.1 Core Dequeue API
 To retrieve the next exported package from the queue, make an HTTP call:
 * **Endpoint:** `GET https://<d365-instance-url>/api/connector/dequeue/<activity-id>`
-* **Response (HTTP 204):** Returned if the export queue is empty.
+* **Response (HTTP 204 — queue empty):** Returned when no messages are waiting. The response body is empty. This is **not an error** — it is the expected "nothing to process" signal. Pollers must handle it by exiting cleanly and waiting for the next scheduled run. Do **not** call `/ack` after a 204; no message was dequeued and there is nothing to acknowledge.
 * **Response (HTTP 200):** Returns a JSON metadata redirect containing the download path and lease lock details:
   ```json
   {
@@ -99,6 +135,9 @@ To retrieve the next exported package from the queue, make an HTTP call:
 
 ### 2.2 Package Download Process
 The connector makes a secondary `GET` call to the `DownloadLocation` URL provided in the dequeue response (passing the OAuth Bearer token in the `Authorization` header) to download the binary ZIP package containing the exported CSV files.
+
+> [!IMPORTANT]
+> In load-balanced environments (e.g. production), the `DownloadLocation` URL returned by `/dequeue` may use `http://` instead of `https://`. This is a known D365 behavior documented by Microsoft. Always replace the URI scheme with `https://` before making the download request — do not follow an HTTP download URL in production.
 
 ### 2.3 Acknowledge (Ack) API
 After successfully downloading and processing the export package, you must send an acknowledgment back to D365. **Until a message is acknowledged, D365 will release the lease lock after 30 minutes, making the message available to dequeue again.**
@@ -115,13 +154,16 @@ After successfully downloading and processing the export package, you must send 
   }
   ```
 
-### 2.4 GUID Mapping Distinction (UI Message ID vs. API CorrelationId)
+### 2.4 GUID Mapping Distinction (UI Message ID vs. API Response Fields)
 * **D365 UI Message ID:** In the D365 SCM UI (**Manage scheduled data jobs > Manage messages**), the GUID displayed under the **"Message ID"** column is the *persistent database record ID* (e.g. `{1EB6FF02-...}`).
-* **API Correlation ID:** The `CorrelationId` in the `/dequeue` JSON response is a *temporary lease lock token* used to link the dequeue session to the acknowledgment POST payload.
-* **Mapping:** D365 resolves the `CorrelationId` internally on `/ack` POST ingestion, updates the corresponding database message record (e.g. `{1EB6FF02-...}`), and updates its status to **Acknowledged** in the UI.
+* **CorrelationId / PopReceipt:** Both fields are returned by the `/dequeue` API. The Microsoft documentation does not describe these fields individually. Send the full dequeue JSON body back unchanged in the `/ack` POST — do not selectively pick fields.
+* **Mapping:** D365 resolves the ack internally, updates the corresponding database message record (e.g. `{1EB6FF02-...}`), and sets its status to **Acknowledged** in the UI.
 
 ### 2.5 Targeted Dequeue by Message ID
 The standard dequeue endpoint always retrieves the **next available message** from the head of the queue. D365 supports an optional `messageId` query parameter to target a **specific message** by its persistent database record GUID (the **UI Message ID** from section 2.4):
+
+> [!NOTE]
+> The `?messageId=` parameter is **not documented in the official Microsoft Learn documentation** for Recurring Integrations. It was discovered through implementation and testing. Behaviour may change across D365 platform updates without notice.
 
 * **Endpoint:** `GET https://<d365-instance-url>/api/connector/dequeue/<activity-id>?messageId=<ui-message-id-guid>`
 * **Behaviour:** D365 locates the specific queue message matching that GUID and returns it in the same `200 OK` JSON response as a standard dequeue call.
@@ -149,7 +191,7 @@ The standard dequeue endpoint always retrieves the **next available message** fr
 #### OMS Implementation
 The `dequeue#RecurringSalesOrderNumbers` service accepts an optional `messageId` parameter. When provided, it appends `?messageId=<value>` to the dequeue URL. The rest of the flow — download, unzip, DataManager upload, and ack — is identical to the standard path.
 
-The `d365_DequeueRecurringSalesOrderNumbers` ServiceJob exposes a `messageId` parameter slot (empty by default). To trigger a targeted re-run, set this parameter to the UI Message ID GUID from the D365 **View messages** screen, run the job once manually, then clear the parameter back to empty so subsequent scheduled runs return to normal queue polling.
+The `d365_DequeueRecurringSalesOrderNumbers` ServiceJob exposes a `messageId` parameter slot (empty by default). To trigger a targeted re-run, set this parameter to the UI Message ID GUID from the D365 **Manage messages** screen, run the job once manually, then clear the parameter back to empty so subsequent scheduled runs return to normal queue polling.
 
 > [!NOTE]
 > The UI Message ID used here is the **persistent database GUID** shown in the D365 "Manage messages" screen — **not** the `CorrelationId` returned by the dequeue response, which is a temporary lease token.
@@ -173,7 +215,7 @@ To monitor enqueued messages, check job runs, and download active payloads direc
 
 ### 3.3 Inspecting and Downloading Queue Payloads
 * Select your scheduled job from the list.
-* In the top action pane, click **View messages** or **Queue status**.
+* In the top action pane, click **Manage messages**.
 * This screen shows each enqueued/dequeued package with its:
   * **Message ID:** Database record GUID.
   * **Message status:** (e.g., `In queue`, `Processed`, `Acknowledged`, `Failed`).

--- a/project-ideas/dynamics365-integration/sales-orders/business_processes.md
+++ b/project-ideas/dynamics365-integration/sales-orders/business_processes.md
@@ -76,9 +76,10 @@ D365 does not store a specific General Ledger (GL) account on the customer recor
 
 ## 3. Sales Orders Sync
 
-Sales orders are synchronized from HotWax OMS to D365 F&O after prerequisite customer creation. The business process is the same regardless of transport method, but the connector currently supports two separate implementation patterns:
+Sales orders are synchronized from HotWax OMS to D365 F&O after prerequisite customer creation. The business process is the same regardless of transport method, but the connector currently supports three separate implementation patterns:
 - **OData pattern**: Direct sync using `SalesOrderHeadersV4` and `SalesOrderLinesV3`.
 - **DMF / Data Package pattern**: Package-based import using the `Sales orders composite V4` composite entity.
+- **Recurring Integrations pattern**: Queue-based enqueue using the same `Sales orders composite V4` composite entity submitted via the D365 Recurring Integrations Scheduler.
 
 > **Prerequisite**: A customer record must exist in D365 before a sales order can be created for that customer. Refer to the [Customer Sync](#2-customer-sync) section for more details.
 
@@ -86,7 +87,7 @@ Sales orders are synchronized from HotWax OMS to D365 F&O after prerequisite cus
 
 - **Order Selection**: Eligible OMS sales orders are identified for export to D365.
 - **Customer Prerequisite**: The bill-to customer is created or verified in D365 before order creation/import.
-- **Order Creation**: The sales order header and lines are sent to D365 using either OData or DMF.
+- **Order Creation**: The sales order header and lines are sent to D365 using OData, DMF, or Recurring Integrations.
 - **Acknowledgment**: The order is considered synced only after the selected integration path reaches its defined success checkpoint.
 - **Downstream Ownership**: Fulfillment, packing slip posting, invoicing, and settlement remain D365-side operational processes.
 
@@ -115,19 +116,31 @@ This pattern creates a composite package and submits it through the Data Managem
 - **Constraint**: Import processing is asynchronous from the business point of view and requires package submission/orchestration.
 - **Current Use Case**: Larger-volume order import and composite payload submission.
 
-#### 3.2.3 Pattern Comparison
+#### 3.2.3 Recurring Integrations Pattern
+This pattern uses the D365 Recurring Integrations Scheduler to enqueue the composite package via a queue endpoint, bypassing the explicit upload step required by the Data Package API.
+
+- **D365 Interface**: D365 Recurring Integrations Scheduler (Queue Connector — `/api/connector/enqueue/{activityId}`)
+- **Composite Entity**: Same `Sales orders composite V4` as the DMF pattern
+- **Processing Style**: Queue-based enqueue — fire-and-forget; D365 processes the package from an internal queue
+- **Status Resolution**: Two-step — Queue Message ID → DMF Execution ID (via `GetExecutionIdByMessageId`) → status (via `GetExecutionSummaryStatus`)
+- **Key Advantage over DMF**: Eliminates the Azure Blob upload step; reduces connection overhead; better suited for high-frequency continuous background flows with built-in queue resilience and load throttling
+- **Constraint**: No direct execution ID on submission; status resolution requires an extra API hop compared to the DMF pattern.
+- **Current Use Case**: High-frequency or continuous background order sync where queue resilience and reduced overhead are preferred.
+
+#### 3.2.4 Pattern Comparison
 
 | Pattern | D365 Interface | Entity Model | Processing Style | Main Constraint |
 | :--- | :--- | :--- | :--- | :--- |
 | OData | `SalesOrderHeadersV4`, `SalesOrderLinesV3` | Separate header and line entities | Direct request/response | Partial order creation on failure |
-| DMF | `Sales orders composite V4` | Composite import package | Batch/asynchronous | Package generation, upload, and import monitoring |
+| DMF | `Sales orders composite V4` | Composite import package | Batch/asynchronous via Azure Blob upload | Package generation, upload, and import monitoring |
+| Recurring Integrations | `Sales orders composite V4` (via Queue Connector) | Composite import package | Queue-based enqueue/asynchronous | Two-step status resolution (Queue MessageId → ExecutionId) |
 
 > [!NOTE]
-> Detailed implementation specifics for both patterns are documented in [implementation_plan.md](implementation_plan.md) and the shared DMF reference at [data_import_package_api.md](../data-package-api/data_import_package_api.md).
+> Detailed implementation specifics for all three patterns are documented in [implementation_plan.md](implementation_plan.md) and the shared DMF reference at [data_import_package_api.md](../data-package-api/data_import_package_api.md).
 
 ### 3.3 Shared Business Rules
 
-The following business rules apply regardless of whether the order is synchronized through OData or DMF.
+The following business rules apply regardless of whether the order is synchronized through OData, DMF, or Recurring Integrations.
 
 - **D365 Order Identity**: `SalesOrderNumber` is the D365-generated order identifier returned after successful creation/import.
 - **External Reference**: HotWax `orderId` is carried as `CustomersOrderReference` to support lookup and reconciliation.

--- a/project-ideas/dynamics365-integration/sales-orders/business_processes.md
+++ b/project-ideas/dynamics365-integration/sales-orders/business_processes.md
@@ -112,6 +112,9 @@ This pattern creates a composite package and submits it through the Data Managem
     - `SALESORDERHEADERV3ENTITY`
     - `SALESORDERLINEV2ENTITY`
     - `SALESORDERHEADERCHARGEV2ENTITY`
+
+> [!NOTE]
+> The "V4" in `Sales orders composite V4` is the composite entity's own version number, not the version of its child sub-entities. The composite uses header **V3** and line **V2** child entities — which are distinct from the standalone OData entities used in the OData pattern (`SalesOrderHeadersV4` / `SalesOrderLinesV3`). These child entity versions are defined by the composite entity schema in D365 and cannot be changed independently.
 - **Processing Style**: Batch/package-based import
 - **Constraint**: Import processing is asynchronous from the business point of view and requires package submission/orchestration.
 - **Current Use Case**: Larger-volume order import and composite payload submission.

--- a/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
+++ b/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
@@ -2,7 +2,7 @@
 
 This document outlines the technical design and implementation steps for integrating HotWax OMS with Microsoft Dynamics 365 Finance & Operations (D365 F&O).
 
-## 1. Technical Architecture
+## Technical Architecture
 - Sales-order integration uses the generic D365 connector foundation documented in [connector_foundation.md](../foundation/connector_foundation.md).
 - **Sales-order specific interfaces**:
     - OData v4 (REST) for direct entity-based sync
@@ -874,10 +874,10 @@ Designed for high-volume and guaranteed document atomicity.
 - **TODO**: [Mapping] Define `facilityId` to D365 warehouse/site mapping, including the strategy for unbrokered OMS orders.
 - **TODO**: [Mapping] Create mapping table for `TaxCategory` -> `ItemSalesTaxGroup`.
 
-## Integration Type Mappings
+### Integration Type Mappings
 To avoid hardcoding values like `SalesOrderOriginCode` and `DeliveryModeCode` in service logic, we use the `IntegrationTypeMapping` entity to translate OMS identifiers into D365 codes.
 
-### Configuration Structure
+#### Configuration Structure
 Add records to the entity `co.hotwax.integration.IntegrationTypeMapping` for the target system:
 
 | Mapping Category | OMS Internal ID (`mappingKey`) | D365 Code (`mappingValue`) | Enum Type (`integrationTypeId`) |
@@ -885,11 +885,11 @@ Add records to the entity `co.hotwax.integration.IntegrationTypeMapping` for the
 | **Sales Order Origin** | OMS Sales Channel (for example `WEB_SALES_CHANNEL`) | D365 Sales Origin (for example `Ecom`) | `D365_SALES_CHNL` |
 | **Delivery Mode** | OMS Shipment Method (for example `STANDARD`) | D365 Mode of Delivery (for example `Standard`) | `D365_SHP_MTHD` |
 
-### Mapping Details
+#### Mapping Details
 - **Sales Order Origin**: Maps the OMS `salesChannelEnumId` (from `OrderHeader`) to the D365 Sales Origin. In D365, this is the 'Sales Origin' field.
 - **Delivery Mode**: Maps the OMS `shipmentMethodTypeId` (from `OrderItemShipGroup`) to the D365 Mode of Delivery. In D365, this is the 'Mode of delivery' field. For mixed-cart orders, first select the shipment method that is not `STOREPICKUP` or `POS_COMPLETED`, and if none exists, fall back to the first non-empty shipment method on the order.
 
-### Setup Steps
+#### Setup Steps
 1. **Define Enumerations**: Add the mapping category IDs (for example `D365_SALES_CHNL`, `D365_SHP_MTHD`) to `moqui.basic.Enumeration`.
 2. **Populate Mappings**: Provide the specific mapping records:
    - `integrationTypeId`: The category ID.
@@ -1138,7 +1138,7 @@ This export reconciles the D365-assigned `InventoryLotId` back to the OMS order 
 
 ### 2.2 Export of Packing Slips (Outbound Shipments) from D365 to OMS
 
-*For complete implementation specifications, architectural decisions, and step-by-step development instructions for synchronizing outbound shipments/packing slips from D365 SCM to OMS, see the [Shipment Export Exploration Notes](file:///Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md).*
+*For complete implementation specifications, architectural decisions, and step-by-step development instructions for synchronizing outbound shipments/packing slips from D365 SCM to OMS, see the [Shipment Export Exploration Notes](./shipment_export_exploration.md).*
 
 ### 3. Brokered Order Items Update from OMS to D365
 

--- a/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md
+++ b/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md
@@ -31,6 +31,7 @@ To prevent duplicate records (e.g., Sales Headers) during retries, OData calls s
 ---
 
 ## 2. Custom Services (SysOperation)
+- **Official Documentation**: [Custom service development](https://learn.microsoft.com/dynamics365/fin-ops-core/dev-itpro/data-entities/custom-services)
 - **Use Case**: Atomic creation of complex documents (Header + Lines) in a single transaction.
 - **Protocol**: REST (JSON/XML) or SOAP.
 - **Description**: A custom X++ endpoint that accepts a full document payload. D365 processes the entire structure within one database transaction.
@@ -91,7 +92,7 @@ Business Events provide a mechanism that lets external systems receive notificat
 
 | Feature | Description |
 | :--- | :--- |
-| **Push-based** | D365 activeley sends a notification when a business process completes. |
+| **Push-based** | D365 actively sends a notification when a business process completes. |
 | **Event-driven** | Reduces load by eliminating the need for external systems to poll OData. |
 | **Standard Events** | Includes `SalesOrderInvoicedBusinessEvent`, `SalesOrderConfirmedBusinessEvent`, etc. |
 

--- a/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md
+++ b/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md
@@ -52,7 +52,7 @@ For Sales Order synchronization where transactional integrity is critical, OData
 
 Integrating with D365 F&O requires a multi-layered security configuration. All API calls execute in the context of a specific D365 user, not a generic application identity.
 
-### 2.1 The Authentication Flow
+### 3.1 The Authentication Flow
 1. **Identity Provider**: Azure Active Directory (Microsoft Entra ID) validates the **App Registration** (Client ID/Secret).
 2. **User Mapping**: The App Registration is mapped to a specific **D365 Finance User** within the ERP.
 3. **Effective Permissions**: All OData calls execute using the mapped user's:
@@ -60,17 +60,17 @@ Integrating with D365 F&O requires a multi-layered security configuration. All A
     - Data Permissions
     - Legal Entity (Company) Access
 
-### 2.2 Configuration in D365
+### 3.2 Configuration in D365
 The mapping is configured at: `System administration > Setup > Microsoft Entra applications`.
 - **Client ID**: The Application ID from Azure.
 - **User ID**: The dedicated service user in D365.
 
-### 2.3 Company (Legal Entity) Access
+### 3.3 Company (Legal Entity) Access
 D365 is a multi-company system. OData visibility is strictly partitioned by `dataAreaId`.
 - **Constraint**: If the service user lacks access to a specific company (Legal Entity), queries will return **empty results** rather than an authorization error.
 - **Requirement**: Assign all required legal entities to the service user at: `System administration > Users > Users > [User] > Companies`.
 
-### 2.4 Best Practices
+### 3.4 Best Practices
 > [!IMPORTANT]
 > - **Dedicated Service User**: Always use a non-human service user (e.g., `svc_hotwax_integration`) for production.
 > - **Explicit Context**: Always include `dataAreaId` in POST payloads and `$filter` by it in GET requests.
@@ -78,15 +78,15 @@ D365 is a multi-company system. OData visibility is strictly partitioned by `dat
 
 ---
 
-## 3. Data Management Framework (DMF)
+## 4. Data Management Framework (DMF)
 - **Use Case**: High-volume asynchronous batch processing. Useful for bulk customer imports or large order migrations.
 - **Official Documentation**: [Data management overview](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/data-entities/data-entities-data-packages)
 
-## 4. Business Events (Near Real-time Outbound)
+## 5. Business Events (Near Real-time Outbound)
 - **Use Case**: Triggering external actions based on D365 internal events (e.g., notifying OMS of a posted invoice).
 - **Official Documentation**: [Business events overview](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/data-entities/business-events/home-page)
 
-### 4.1 Key Concepts
+### 5.1 Key Concepts
 Business Events provide a mechanism that lets external systems receive notifications from Finance and Operations. This is the **recommended methodology** for "D365 -> OMS" push notifications.
 
 | Feature | Description |
@@ -95,7 +95,7 @@ Business Events provide a mechanism that lets external systems receive notificat
 | **Event-driven** | Reduces load by eliminating the need for external systems to poll OData. |
 | **Standard Events** | Includes `SalesOrderInvoicedBusinessEvent`, `SalesOrderConfirmedBusinessEvent`, etc. |
 
-### 4.2 Integration Patterns
+### 5.2 Integration Patterns
 Business events can be consumed through various endpoints:
 
 1.  **Azure Power Automate**: The most common "low-code" approach using the D365 F&O connector.
@@ -103,19 +103,49 @@ Business events can be consumed through various endpoints:
 3.  **Azure Service Bus**: For reliable, asynchronous messaging and queuing.
 4.  **Azure Event Grid**: For high-scale event routing.
 
-### 4.3 Comparison: OData vs. Business Events
+### 5.3 Comparison: OData vs. Business Events
 - **OData (Pull)**: Best for synchronous CRUD or batch data retrieval where the OMS initiates the request.
 - **Business Events (Push)**: Best for reactive workflows where D365 must notify the OMS of a state change (e.g., fulfillment complete).
 
 ---
 
-## 5. Shipment Export via Data Entities
-- **Goal**: Export shipment details with source-side filtering so only required fulfillment lines are synchronized to OMS.
-- **Source entities**:
-  - `CustPackingSlipJourBiEntities` (packing slip header)
-  - `CustPackingSlipTransBiEntities` (packing slip lines)
-  - `PackingSlipTrackingInformation` (tracking and carrier details)
-- **Entity grain**: One export row per shipment line (or per shipment line + tracking number, based on tracking cardinality).
-- **Export mechanism**: Data Management Framework (DMF) recurring export.
-- **Consumption mechanism**: Middleware polls recurring integration dequeue APIs, processes export packages, and acknowledges consumption.
-- **Payload shaping**: DMF exports tabular records; middleware groups rows (for example by `packingSlipId`) to construct nested OMS shipment payloads.
+## 6. Recurring Integrations Scheduler
+- **Use Case**: Continuous, queue-based import or export of data packages without requiring the external system to manage Azure Blob upload/download URLs.
+- **Official Documentation**: [Recurring integrations](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/data-entities/recurring-integrations)
+
+### 6.1 Key Concepts
+
+The Recurring Integrations Scheduler exposes two queue-based APIs that sit on top of the same DMF pipeline: an **Enqueue API** for inbound data (OMS → D365) and a **Dequeue API** for outbound data (D365 → OMS).
+
+| Feature | Description |
+| :--- | :--- |
+| **Queue-based** | External system enqueues or dequeues packages; D365 manages the internal queue |
+| **Same DMF pipeline** | Uses the same composite entities and definition groups as the Data Package API |
+| **No Azure Blob management** | Eliminates explicit Azure Blob upload/download URL handling required by the Data Package API |
+| **Asynchronous** | Processing is non-blocking; status is resolved separately via `GetExecutionIdByMessageId` |
+
+### 6.2 Enqueue API (Inbound: OMS → D365)
+
+Used to submit data packages into D365 without uploading to Azure Blob Storage directly.
+
+- **Endpoint**: `POST /api/connector/enqueue/{activityId}`
+- **Returns**: A Queue Message ID (GUID)
+- **Status resolution**: Two-step — `GetExecutionIdByMessageId` (Queue Message ID → DMF Execution ID) → `GetExecutionSummaryStatus` (Execution ID → status)
+- **Suitable for**: High-frequency or continuous background inbound flows (e.g., sales order import, arrival journal import)
+
+### 6.3 Dequeue API (Outbound: D365 → OMS)
+
+Used to pull pre-scheduled D365 export packages from a recurring job queue.
+
+- **Endpoints**: `GET /api/connector/dequeue/{activityId}` → download via Blob redirect → `POST /api/connector/ack/{activityId}` (acknowledgment)
+- **Returns**: A package URL for download; acknowledgment clears the item from the queue
+- **Suitable for**: Polling-based outbound flows where D365 generates export packages on a schedule (e.g., sales order number export, product variant export)
+
+### 6.4 Comparison: Data Package API vs. Recurring Integrations API
+
+| Feature | Data Package API | Recurring Integrations API |
+| :--- | :--- | :--- |
+| **Azure Blob** | External system manages upload/download URLs | Managed internally by D365 |
+| **Status** | Execution ID returned directly on import | Queue Message ID → Execution ID (extra hop) |
+| **Best for** | On-demand, controlled batch imports | High-frequency, continuous background flows |
+| **Outbound** | `ExportToPackage` + `GetExportedPackageUrl` | Dequeue + Ack pattern |

--- a/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
+++ b/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
@@ -38,7 +38,10 @@ Settlement                 ←── Posted payment applied to open invoice(s)
 ### 2.1 Standard E-Commerce Order (Warehouse Fulfilled)
 
 - Order is fulfilled from a D365-managed warehouse.
-- D365 owns picking, packing slip, and invoice posting. //TODO verify this about invoice posting. 
+- D365 owns picking, packing slip, and invoice posting.
+
+> [!NOTE]
+> **TODO**: Verify that invoice posting is fully owned by D365 (not triggered by OMS).
 - OMS pushes a customer payment journal after the order is settled in Shopify.
 - D365 settles the posted payment against the posted invoice using the shared `SalesOrderNumber` as the matching key.
 
@@ -143,7 +146,7 @@ A custom X++ `SysOperation` batch class was implemented in the `dynamics365-inte
 
 For each customer with open transactions, the service:
 1. Collects open invoices (`CustTrans` where `TransType = Invoice`), reading `SalesId` from each.
-2. Collects open payments (`CustTrans` where `TransType = Payment`), reading `PaymReference` from each — which OMS populates with the D365 `SalesOrderNumber`.
+2. Collects open payments (`CustTrans` where `TransType = Payment`), reading `PaymReference` from each — the X++ `CustTrans` field name for what the OData API calls `PaymentReference`, which OMS populates with the D365 `SalesOrderNumber`.
 3. Settles only pairs where `invoice.SalesId == payment.PaymReference`.
 
 This ensures a payment for Order B is never applied to Order A's invoice, regardless of invoice age.
@@ -237,7 +240,7 @@ POS Completed orders require a tightly automated lifecycle since payment is capt
 ## 7. Key Technical Observations
 
 - **Journal created unposted**: OData creates the payment journal in draft (`IsPosted = No`). Posting is a separate operation. If posting fails (e.g., due to missing bank account mapping), the journal stays unposted and payments appear pending in D365.
-- **`PaymentReference` is the settlement anchor**: OMS writes `d365SalesOrderNumber` into `PaymentReference` on every journal line. The custom settlement service (`HotWaxAutoPostSettlementService`) matches on `PaymReference = SalesId`. If this field mapping is ever changed in OMS, the settlement service must be updated in sync.
+- **`PaymentReference` / `PaymReference` is the settlement anchor**: OMS writes `d365SalesOrderNumber` into `PaymentReference` (OData API field name) on every journal line. The custom settlement service (`HotWaxAutoPostSettlementService`) reads this as `PaymReference` — the X++ `CustTrans` field name for the same field — and matches on `PaymReference = SalesId`. If this field mapping is ever changed in OMS, the settlement service must be updated in sync.
 - **OOTB settlement cannot be used**: D365 OOTB auto-settlement and periodic settlement both operate at customer account level using FIFO due-date ordering. They have no mechanism to honor `PaymentReference`. See [section 5.1](#51-why-ootb-d365-settlement-is-insufficient) for the full failure scenario.
 - **Multiple invoices per order**: A mixed-cart or partially-fulfilled order can produce 2–4 invoices. The custom settlement service handles this iteratively — each posted payment is matched against all open invoices for the same `SalesId` until the payment is exhausted or all invoices are closed.
 - **Settlement is D365-internal**: OMS has no direct role in triggering settlement. The custom batch job runs inside D365 on a schedule and operates entirely on D365-side `CustTrans` records.
@@ -280,8 +283,8 @@ These scenarios cover the `HotWaxAutoPostSettlementService` custom X++ settlemen
 | # | Scenario | Result |
 | :--- | :--- | :--- |
 | 9 | **SalesId filter** — run with a specific `SalesId` in the contract dialog. Only that order is settled; all others are untouched. | Pending |
-| 10 | **FromDate filter** — set `FromDate` to tomorrow's date. No invoices qualify, settled count = 0. Then set to today or earlier — invoices are picked up. | Pending |
-| 11 | **No filters (default)** — empty `SalesId`, empty `FromDate`. All eligible orders processed in one run. | Pending |
+| 10 | **TransDate filter** — set `TransDate` to tomorrow's date. No invoices qualify, settled count = 0. Then set to today or earlier — invoices are picked up. | Pending |
+| 11 | **No filters (default)** — empty `SalesId`, empty `TransDate`. All eligible orders processed in one run. | Pending |
 
 ### 8.5 Idempotency / Re-run Safety
 
@@ -316,7 +319,7 @@ These scenarios cover the `HotWaxAutoPostSettlementService` custom X++ settlemen
 | 7 | Invoice exists, no payment — warning logged | ✓ |
 | 8 | Payment exists, no invoice yet | Pending |
 | 9 | SalesId filter | Pending |
-| 10 | FromDate filter | Pending |
+| 10 | TransDate filter | Pending |
 | 11 | No filters (default) | Pending |
 | 12 | Re-run on already-settled order — no double settlement | ✓ |
 | 13 | Same customer, two orders — each payment settles its own invoice only | ✓ **Critical** |
@@ -326,7 +329,7 @@ These scenarios cover the `HotWaxAutoPostSettlementService` custom X++ settlemen
 
 ---
 
-## 10. Open Items / TODOs
+## 9. Open Items / TODOs
 
 | Item | Priority | Notes |
 | :--- | :--- | :--- |
@@ -336,7 +339,7 @@ These scenarios cover the `HotWaxAutoPostSettlementService` custom X++ settlemen
 
 ---
 
-## 11. Official References
+## 10. Official References
 
 - [Accounts receivable overview](https://learn.microsoft.com/en-us/dynamics365/finance/accounts-receivable/accounts-receivable)
 - [Customer payment journal](https://learn.microsoft.com/en-us/dynamics365/finance/accounts-receivable/customer-payment-journal)
@@ -348,7 +351,7 @@ These scenarios cover the `HotWaxAutoPostSettlementService` custom X++ settlemen
 
 ---
 
-## 12. Related Docs
+## 11. Related Docs
 
 - [Business Processes](./business_processes.md) — Section 4 (Customer Payment Management) and Section 5 (Fulfillment & Invoicing).
 - [Implementation Plan](./implementation_plan.md) — Customer Payment Integration section and POS Completed Orders Sync section.

--- a/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
+++ b/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
@@ -207,7 +207,7 @@ POS Completed orders require a tightly automated lifecycle since payment is capt
 2. D365 auto-posts packing slip — OOTB batch (`Sales and marketing > Order shipping > Post packing slip`, filtered by `SalesOrigin = POS`). Validated in issue [#13](https://github.com/hotwax/dynamics365-integration/issues/13).
 3. D365 auto-posts invoice — OOTB batch (`AR > Invoices > Batch invoicing > Invoice`, filtered by `SalesOrigin = POS`). Validated in issue [#16](https://github.com/hotwax/dynamics365-integration/issues/16).
 4. OMS pushes customer payment journal (OData, unposted draft).
-5. D365 posts the payment journal — OOTB AR auto-post or custom batch (under evaluation for target environment).
+5. D365 posts the payment journal — OOTB AR auto-post batch. Validated.
 6. `HotWaxAutoPostSettlementService` runs and settles the posted payment against the posted invoice using `PaymReference = SalesId`.
 
 **Status**: Steps 1–3 validated. Step 6 (settlement service) implemented and verified in isolation. End-to-end POS lifecycle not yet verified as a complete chain.
@@ -229,7 +229,7 @@ POS Completed orders require a tightly automated lifecycle since payment is capt
 | :--- | :--- | :--- |
 | Packing slip auto-post | OOTB ✓ | Standard D365 batch (`Sales and marketing > Post packing slip`). Validated — see issues #13, #15. |
 | Invoice auto-post | OOTB ✓ | Standard D365 batch (`AR > Invoices > Batch invoicing > Invoice`). Validated — see issues #16, #17. |
-| Payment journal post | OOTB (under evaluation) | Can be configured via AR parameters auto-post. Needs validation in target environment. |
+| Payment journal post | OOTB ✓ | Standard D365 AR auto-post batch. Validated. |
 | Settlement | Custom ✓ | OOTB rejected (FIFO by customer, ignores `PaymentReference`). Custom `HotWaxAutoPostSettlementService` implemented — see [section 5.2](#52-custom-settlement-service-hotwaxautopostsettlementservice). |
 
 ---

--- a/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
+++ b/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
@@ -53,13 +53,13 @@ Settlement                 ←── Posted payment applied to open invoice(s)
 
 **Status**: Fulfilled order items warehouse update implemented. Invoice posting and settlement remain D365-side steps (OOTB or custom batch). Not end-to-end verified.
 
-### 2.3 POS Carry-Out Order
+### 2.3 POS Completed Order
 
-- Order is placed at POS, payment is captured immediately (carry-out: fulfilled on the spot).
-- Requires a tightly automated lifecycle in D365: packing slip → invoice → payment post → settlement, all happening close together.
-- Because the customer has already paid at point of sale, automated settlement against the same-session invoice is the target behavior.
-
-**Status**: Explored. POS order sync itself is implemented (same sales order path). Automated packing slip posting, invoice posting, payment posting, and settlement require D365-side automation (OOTB batch or custom X++ SysOperation). Not yet verified end-to-end.
+- Order is placed and fulfilled at the store counter in a single transaction; payment is captured immediately via the payment gateway.
+- OMS pushes the sales order to D365 (same path as other order types) when the order reaches `COMPLETED` status.
+- D365-side automation handles packing slip posting and invoice generation (OOTB batch or custom X++).
+- OMS pushes the customer payment journal to D365 after confirming payment settlement in Shopify.
+- D365 settles the posted payment against the posted invoice using `SalesOrderNumber` as the matching key.
 
 ### 2.4 Mixed Cart Order (Store + Warehouse Lines)
 
@@ -201,7 +201,7 @@ The service runs as a recurring D365 batch job. Access it from the HotWax custom
 
 ### 5.4 POS Order Settlement Flow
 
-POS carry-out orders require a tightly automated lifecycle since payment is captured at the point of sale. Steps 1–3 use validated OOTB D365 batch jobs; step 4 uses the custom settlement service.
+POS Completed orders require a tightly automated lifecycle since payment is captured at the point of sale. Steps 1–3 use validated OOTB D365 batch jobs; step 4 uses the custom settlement service.
 
 1. OMS pushes sales order to D365.
 2. D365 auto-posts packing slip — OOTB batch (`Sales and marketing > Order shipping > Post packing slip`, filtered by `SalesOrigin = POS`). Validated in issue [#13](https://github.com/hotwax/dynamics365-integration/issues/13).

--- a/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
+++ b/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
@@ -64,10 +64,10 @@ Settlement                 ←── Posted payment applied to open invoice(s)
 ### 2.4 Mixed Cart Order (Store + Warehouse Lines)
 
 - A single sales order contains lines fulfilled by both D365 (warehouse) and OMS (store).
-- D365 generates **multiple invoices** from the same order as different fulfillment events complete.
-- Settlement must match the payment against multiple invoices over time.
-
-**Status**: Mixed cart order creation and per-line warehouse update implemented. Multi-invoice settlement strategy is designed but not yet verified end-to-end.
+- OMS pushes the sales order to D365 and updates warehouse context per fulfillment event — warehouse lines via the Brokered Order Items package, store-fulfilled lines via the Fulfilled Order Items package.
+- D365 generates **multiple invoices** from the same order as different fulfillment events complete — one per fulfillment wave.
+- OMS pushes a customer payment journal after payment is settled in Shopify.
+- D365 settles the posted payment against multiple invoices over time using `SalesOrderNumber` as the matching key.
 
 > [!NOTE]
 > The identified matching key for all settlement use cases is `SalesOrderNumber`. OMS writes this into `PaymentReference` on the payment journal line. Any future D365 settlement batch or custom settlement logic should be built around that identifier.

--- a/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md
+++ b/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md
@@ -89,15 +89,34 @@ This section defines the components in the `hotwax-d365` connector to schedule, 
 - **D365 Definition Group**: `HotWax_Export_Packing_Slips`
 - **D365 Package Name**: `OmsPackingSlipExportEntity`
 - **Target CSV Filename**: `Oms packing slip export entity.csv`
-- **DataManager Configuration**: `D365_IMP_PACKING_SLIPS`
+- **DataManager Configuration**: `D365_IMP_PACKING_SLIPS` (the `IMP` prefix follows the OMS DataManager naming convention — it represents an OMS-side import of the D365 export data, consistent with `D365_IMP_SALES_ORD` used in other D365-to-OMS export flows)
 - **Processing Service**: `co.hotwax.d365.D365ShipmentServices.storeAndCreate#D365OutboundShipments`
 
-### Processing Flow
-1. **Triggering**: The queue job `d365_QueuePackingSlipsExport` triggers `D365DataPackageServices.queue#ExportDataPackage` which sets up a `SystemMessage` record.
-2. **Execution**: The `send#ExportDataPackage` service issues a request to D365 `ExportToPackage` for the `HotWax_Export_Packing_Slips` group.
-3. **Polling**: The `d365_ExportPackingSlipsPoll` service monitors the job status until completion.
-4. **Ingestion**: Upon completion, the checker downloads the export package, extracts the CSV, and initiates the `D365_IMP_PACKING_SLIPS` DataManager parsing flow.
-5. **Consumption**: Tabular rows are passed to `storeAndCreate#D365OutboundShipments` for processing.
+### Candidate OMS Integration Approaches
+
+> [!NOTE]
+> **Approach not finalized.** Two options are under consideration. Both use the same D365 entity (`OmsPackingSlipExportEntity`), definition group (`HotWax_Export_Packing_Slips`), and downstream processing service (`storeAndCreate#D365OutboundShipments`). The choice affects the Moqui queue/poll service names and how D365 is configured.
+
+#### Option A: Data Package Export API
+
+1. A queue job triggers `D365DataPackageServices.queue#ExportDataPackage`, which queues a `SystemMessage` and calls D365 `ExportToPackage` for the `HotWax_Export_Packing_Slips` definition group.
+2. A poll job calls `GetExecutionSummaryStatus` until the export status is `Succeeded`.
+3. `GetExportedPackageUrl` is called to retrieve a signed blob download URL.
+4. The ZIP is downloaded, the target CSV (`Oms packing slip export entity.csv`) is extracted, and the `D365_IMP_PACKING_SLIPS` DataManager flow processes the rows.
+5. Tabular rows are passed to `storeAndCreate#D365OutboundShipments`.
+
+**Trade-off**: OMS controls export timing (triggered on demand). Requires the full ExportToPackage → poll → download cycle per run.
+
+#### Option B: Recurring Integration (dequeue/ack)
+
+1. A recurring export job is configured in D365 Data Management for `HotWax_Export_Packing_Slips` to run on a schedule.
+2. Moqui polls the `/api/connector/dequeue/{activityId}` endpoint on its own schedule; each successful response contains a download URL for the exported CSV package.
+3. The CSV is downloaded and rows are processed through `D365_IMP_PACKING_SLIPS` DataManager and `storeAndCreate#D365OutboundShipments`.
+4. Moqui calls `/api/connector/ack/{activityId}` to prevent reprocessing.
+
+**Trade-off**: D365 drives the export schedule; OMS only polls and acknowledges. Simpler OMS-side triggering, but export cadence is configured in D365.
+
+For reference on both APIs, see [recurring_integrations_api.md](../recurring-integrations/recurring_integrations_api.md) and [data_export_package_api.md](../data-package-api/data_export_package_api.md).
 
 ### Exported Fields & Mappings
 

--- a/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md
+++ b/project-ideas/dynamics365-integration/sales-orders/shipment_export_exploration.md
@@ -159,6 +159,6 @@ To process the flat lines from the CSV and construct the hierarchical shipments,
 ## Related References
 - D365 Integration Issue: [hotwax/dynamics365-integration#23](https://github.com/hotwax/dynamics365-integration/issues/23)
 - Exploration Issue: [hotwax/hotwax-d365#51](https://github.com/hotwax/hotwax-d365/issues/51)
-- Business process reference: [business_processes.md](file:///Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/business_processes.md)
-- Integration methodology reference: [integration_methodologies.md](file:///Users/gurveenkaur/Documents/Work/git/oms/moqui-framework/runtime/component/foundation/project-ideas/dynamics365-integration/sales-orders/integration_methodologies.md)
+- Business process reference: [business_processes.md](business_processes.md)
+- Integration methodology reference: [integration_methodologies.md](integration_methodologies.md)
 


### PR DESCRIPTION
Section 3 previously documented only OData and DMF patterns. Added the Recurring Integrations pattern (queue#RecurringSalesOrders via Queue Connector) as a distinct 3.2.3 subsection, updated the comparison table to include all three patterns, and updated all references from "two" to "three" patterns throughout the section.