### PR TITLE
docs(d365): expand sales-orders financial config, sync, and payment docs

### DIFF
--- a/project-ideas/dynamics365-integration/sales-orders/business_processes.md
+++ b/project-ideas/dynamics365-integration/sales-orders/business_processes.md
@@ -64,6 +64,19 @@ D365 does not store a specific General Ledger (GL) account on the customer recor
     - When a Sales Invoice is posted, the system reads the `CustomerGroupId` from the customer record.
     - It then looks up the **Customer Posting Profile** (configured in AR setup).
     - The Posting Profile identifies which **Main Account** (e.g., Accounts Receivable - Domestic) to debit based on that specific Group.
+
+> [!NOTE]
+> **Scope: this only resolves the receivable side of the invoice.** A posted sales invoice is a single voucher with multiple debit/credit lines, and each line's Main Account is chosen by an independent posting-setup rule — Customer Group only controls the first one:
+>
+> | Line | Main Account | What decides it |
+> | :--- | :--- | :--- |
+> | Debit (Customer balance) | AR trade account | Customer → Customer Group → **Customer Posting Profile** |
+> | Credit (Revenue) | Sales Revenue | Item → Item Group → item posting setup |
+> | Credit (Tax) | Sales Tax Payable | Sales Tax Group setup |
+> | Debit/Credit (COGS) | COGS / Inventory | Item Group → inventory posting setup |
+>
+> Revenue, tax, and COGS accounts are **not** affected by which Customer Group a customer belongs to — they're driven entirely by the item and tax configuration. See [Customer posting profiles](https://learn.microsoft.com/dynamics365/finance/accounts-receivable/customer-posting-profiles#posting-examples) (Customer balance posting type), [Posting profiles overview](https://learn.microsoft.com/dynamics365/finance/general-ledger/pstg-prfles-ovrvw#detail-settings-for-a-posting-profile), and [Accounts receivable posting](https://learn.microsoft.com/dynamics365/finance/general-ledger/accts-recvble-posting).
+
 3.  **Default Data**: Beyond accounting, the group also provides defaults for:
     - **Terms of Payment** (e.g., Net 30, Due upon receipt).
     - **Sales Tax Group** (if not overridden on the customer).
@@ -71,6 +84,44 @@ D365 does not store a specific General Ledger (GL) account on the customer recor
 #### Mandatory Requirement
 - **Scope**: Must exist within the same `dataAreaId`.
 - **Validation**: Creation of a customer via OData **will fail** if a valid `CustomerGroupId` is not provided.
+
+### 2.6 Sales Tax Group Risk (Destination-Based Tax)
+
+A **Sales tax group** can be set on the customer group or on the individual customer's **Invoice and delivery** FastTab. If it is set, it takes priority over the shipping/destination address for tax calculation.
+
+- **Risk**: HotWax orders ship to varying addresses nationwide. If `CustomerGroupId 30` (or the customer record itself) carries a default sales tax group, every order could be taxed based on that fixed group instead of the actual delivery address — a silent tax-miscalculation, not a sync failure.
+- **Recommendation**: For a B2C/ship-to-many-addresses model, leave **Sales tax group** blank on both the customer group and the customer record so destination-based tax resolves correctly from the order's shipping address.
+- **Action**: Verify whether `CustomerGroupId 30` has a default tax group configured in the target environment.
+
+> [!NOTE]
+> This is an environment configuration item, not a connector code change — the connector does not currently set `Sales tax group` on customer creation.
+
+- **Reference**: [Configure sales tax for online orders](https://learn.microsoft.com/en-us/dynamics365/commerce/sales-tax-config#customer-account-based-taxes-for-online-orders)
+
+### 2.7 Credit Management Interaction
+
+D365 can block sales order creation, packing slip updates, or invoice posting if a customer's balance and open transactions exceed a configured credit limit. This check can happen at the point the connector creates a sales order via OData or DMF/Recurring Integrations.
+
+- **Risk**: If credit limit checking is enabled for the target environment (via `Credit limit type` in Credit and collections parameters) and `CustomerGroupId 30` does not have **Unlimited credit limit** or **Exclude from credit management** set, `sync#SalesOrders` could fail intermittently for customers near/over their limit — a scenario that looks like a connector defect but is actually a credit hold.
+- **Typical B2C pattern**: Since HotWax captures payment at order time rather than extending open terms, the customer group is typically configured with **Unlimited credit limit = Yes** or **Exclude from credit management = Yes**, removing this as a blocking concern.
+- **Action**: Confirm with the D365 Finance/Functional team whether credit limit checking is enabled for group `30`, and if so, whether B2C orders should be excluded.
+
+- **References**:
+    - [Credit and collections overview](https://learn.microsoft.com/en-us/dynamics365/finance/accounts-receivable/cm-credit-and-collections-overview)
+    - [Credit limits for customers](https://learn.microsoft.com/en-us/dynamics365/supply-chain/sales-marketing/credit-limits-customers)
+
+### 2.8 Customer Change Approval Workflow
+
+D365 supports an optional approval workflow for changes to specific customer fields (`Accounts receivable parameters > Customer approval`). If enabled, updates to enabled fields (potentially including `CustomerGroupId` or credit-related fields) via an entity import behave according to one of three configured modes:
+
+- **Allow changes without approval** — the connector's `sync#Customer` updates apply immediately (no impact).
+- **Reject changes** — the import fails for workflow-enabled fields.
+- **Create change proposals** — the change is staged as a pending proposal and does not take effect until manually approved.
+
+> [!NOTE]
+> If this workflow is enabled in the target environment and configured to `Create change proposals`, a `sync#Customer` update could appear to succeed while the actual field change remains pending — not a connector bug. Confirm whether this workflow is enabled before relying on synchronous customer updates.
+
+- **Reference**: [Customer workflow](https://learn.microsoft.com/en-us/dynamics365/finance/accounts-receivable/customer-workflow)
 
 ---
 
@@ -90,6 +141,9 @@ Sales orders are synchronized from HotWax OMS to D365 F&O after prerequisite cus
 - **Order Creation**: The sales order header and lines are sent to D365 using OData, DMF, or Recurring Integrations.
 - **Acknowledgment**: The order is considered synced only after the selected integration path reaches its defined success checkpoint.
 - **Downstream Ownership**: Fulfillment, packing slip posting, invoicing, and settlement remain D365-side operational processes.
+- **Navigation (View Synced Order)**: `Accounts receivable > Orders > All sales orders` — search by `CustomersOrderReference` (HotWax `orderId`) or the D365-generated `SalesOrderNumber`.
+
+- **Reference**: [Create sales order invoices](https://learn.microsoft.com/en-us/dynamics365/finance/accounts-receivable/tasks/create-sales-order-invoices) (confirms the `Accounts receivable > Orders > All sales orders` path).
 
 ### 3.2 Supported Integration Patterns
 
@@ -115,6 +169,20 @@ This pattern creates a composite package and submits it through the Data Managem
 
 > [!NOTE]
 > The "V4" in `Sales orders composite V4` is the composite entity's own version number, not the version of its child sub-entities. The composite uses header **V3** and line **V2** child entities — which are distinct from the standalone OData entities used in the OData pattern (`SalesOrderHeadersV4` / `SalesOrderLinesV3`). These child entity versions are defined by the composite entity schema in D365 and cannot be changed independently.
+
+#### Shipping Charge (`SALESORDERHEADERCHARGEV2ENTITY`)
+
+The order's shipping charge is sent as a single header-level charge line, using a hardcoded charges code:
+
+- `FIXEDCHARGEAMOUNT` — the calculated shipping charge amount (defaults to `0` if missing).
+- `SALESCHARGECODE` — hardcoded to `'FREIGHT'` in the current implementation. No dynamic lookup/mapping exists.
+
+> [!NOTE]
+> Shipping charge sync is currently only possible via the **DMF pattern**. The OData pattern (`SalesOrderHeadersV4` / `SalesOrderLinesV3`) has no header-level charge entity, so shipping charges cannot be synced through that path.
+
+- **Prerequisite**: A `FREIGHT` charges code must already exist in the target D365 environment (`dataAreaId`-scoped) before this pattern can post successfully.
+- **Navigation (Setup)**: `Accounts receivable > Charges setup > Charges code`
+- **Reference**: [Create charges codes](https://learn.microsoft.com/en-us/dynamics365/finance/accounts-receivable/create-charges-codes)
 - **Processing Style**: Batch/package-based import
 - **Constraint**: Import processing is asynchronous from the business point of view and requires package submission/orchestration.
 - **Current Use Case**: Larger-volume order import and composite payload submission.
@@ -126,9 +194,13 @@ This pattern uses the D365 Recurring Integrations Scheduler to enqueue the compo
 - **Composite Entity**: Same `Sales orders composite V4` as the DMF pattern
 - **Processing Style**: Queue-based enqueue — fire-and-forget; D365 processes the package from an internal queue
 - **Status Resolution**: Two-step — Queue Message ID → DMF Execution ID (via `GetExecutionIdByMessageId`) → status (via `GetExecutionSummaryStatus`)
+- **Navigation (Queue/Message Monitoring)**: `System administration` workspace (not the System administration *module*) → **Data Management IT** workspace → **Recurring data job** tab → select the job to open **Manage scheduled data jobs**, which lists queued/processed messages and their status. Useful for support/ops staff checking queue health without calling `GetExecutionIdByMessageId` / `GetExecutionSummaryStatus` directly.
 - **Key Advantage over DMF**: Eliminates the Azure Blob upload step; reduces connection overhead; better suited for high-frequency continuous background flows with built-in queue resilience and load throttling
 - **Constraint**: No direct execution ID on submission; status resolution requires an extra API hop compared to the DMF pattern.
 - **Current Use Case**: High-frequency or continuous background order sync where queue resilience and reduced overhead are preferred.
+
+> [!NOTE]
+> **Reference**: [Recurring integrations — Manage recurring data jobs](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/data-entities/recurring-integrations#manage-recurring-data-jobs)
 
 #### 3.2.4 Pattern Comparison
 
@@ -167,17 +239,21 @@ HotWax OMS sends the shipping address as part of the sales order data so the del
     - Uses order header delivery address fields
     - Explicitly sets `IsDeliveryAddressOrderSpecific = Yes`
 - **DMF Pattern**:
-    - Supplies address attributes through the composite header entity
-- **Key Business Fields**:
-    - Recipient name
-    - Street
-    - City
-    - State/Province
-    - Postal code
-    - Country/region
+    - Supplies the same address attributes through the composite header entity (uppercase field names, e.g. `DELIVERYADDRESSNAME`)
+- **Key Business Fields** (D365 header field names):
+    - `DeliveryAddressName` — recipient name
+    - `DeliveryAddressDescription` — hardcoded to `'OMS Ship To'` in the current implementation
+    - `DeliveryAddressStreet`
+    - `DeliveryAddressCity`
+    - `DeliveryAddressStateId`
+    - `DeliveryAddressZipCode`
+    - `DeliveryAddressCountryRegionId`
 
 > [!NOTE]
 > The OData implementation explicitly sets `IsDeliveryAddressOrderSpecific = Yes`. The exact read-back behavior in D365 responses should still be validated in the target environment.
+
+> [!NOTE]
+> No `SalesTaxGroup` is set anywhere in this address-building logic, on either the OData or DMF path. This is consistent with (and does not undermine) the destination-based tax recommendation in [2.6 Sales Tax Group Risk](#26-sales-tax-group-risk-destination-based-tax) — as long as the customer/customer-group-level tax group stays blank, this delivery address data has a clear, uncontested path to drive destination-based tax calculation.
 
 ---
 
@@ -192,6 +268,18 @@ Customer payments from HotWax OMS are captured in D365 F&O as **Customer Payment
 - **Current Idempotency Pattern**:
     - Header lookup uses `Description = OMS Payment Journal - SO <d365SalesOrderNumber>`.
     - Line lookup uses `PaymentId = orderPaymentPreferenceId`.
+- **Navigation (View/Manually Post Journal)**: `Accounts receivable > Payments > Customer payment journal`
+- **Reference**: [Customer payment overview](https://learn.microsoft.com/en-us/dynamics365/finance/cash-bank-management/tasks/customer-payment-overview)
+
+#### Header/Line Field Defaults
+
+| Field | Value | Note |
+| :--- | :--- | :--- |
+| `JournalName` | Hardcoded `'OMSPAY'` | **TODO**: Revisit — confirm this should remain a fixed literal rather than be sourced from configuration. |
+| `AccountType` | `'Cust'` | Standard/structural value for this journal type — not environment-specific, no revisit needed. |
+| `CurrencyCode` | Hardcoded `'USD'` | **TODO**: Revisit alongside the open Sales Currency Code question in [8.3](#83-financial-configuration) — this hardcode affects payments, not just customer creation. |
+| `OffsetAccountType` / `OffsetAccountDisplayValue` | Hardcoded `'Bank'` / `'USMF OPER'` | **TODO**: Revisit — the connector code itself flags this gap (`Proper mapping for OffsetAccountDisplayValue based on paymentMethodTypeId`). Every payment currently posts through one fixed bank/clearing account regardless of the customer's actual payment method. |
+| Payment Method | OData path sets no payment-method field at all. DMF/Data Package path resolves `PAYMENTMETHODNAME` via `IntegrationTypeMapping`, falling back to hardcoded `'CASH'` if unmapped. | **TODO**: Revisit — align OData and DMF behavior, and confirm the `'CASH'` fallback is acceptable for unmapped payment methods. |
 
 ### 4.2 Prepayment vs. Standard Payment
 - **Standard Payment (On-Account)**:
@@ -208,6 +296,9 @@ Customer payments from HotWax OMS are captured in D365 F&O as **Customer Payment
 2.  **Invoice Generation**: Later, when the order is fulfilled, a Sales Invoice is created.
 3.  **Settlement**: The custom `HotWaxAutoPostSettlementService` batch job (D365-side) matches the posted payment to its invoice using `PaymReference = SalesOrderNumber`. OOTB D365 automatic settlement was evaluated and rejected — it settles at customer account level (FIFO by due date) and cannot honor the order-specific payment reference.
 
+- **Navigation (Journal Posting Batch — OOTB)**: `General Ledger > Journal entries > Post journals`, filtered by `Journal type = Customer payment`, `Journal name = OMSPAY`, `Posted = No`, with `Late selection = Yes` and running in the background. Verified working in a dev D365 environment — see [hotwax/hotwax-d365#26](https://github.com/hotwax/hotwax-d365/issues/26).
+- **Navigation (Settlement Trigger)**: The custom `HotWaxAutoPostSettlementService` runs as a recurring D365 batch job, accessed from the HotWax custom menu extension → **Auto Post Settlement**. See [invoice_settlement.md](./invoice_settlement.md) for full trigger and configuration details.
+
 > [!NOTE]
 > The connector creates unposted payment journal headers and lines. Journal **posting** is handled by a D365 batch job. **Settlement** is handled by the custom `HotWaxAutoPostSettlementService`. For full design, implementation details, and test scenarios see [invoice_settlement.md](./invoice_settlement.md).
 
@@ -216,6 +307,12 @@ Customer payments from HotWax OMS are captured in D365 F&O as **Customer Payment
 ## 5. Fulfillment
 
 Fulfillment ownership is determined at the order item (line) level. A single sales order can contain lines fulfilled by OMS (stores) and lines fulfilled by D365 (warehouses). Each path sends a different data feed to D365 and triggers packing slip posting through a different mechanism.
+
+> [!NOTE]
+> `ShippingWarehouseId` (`SHIPPINGWAREHOUSEID` in DMF) is set to a hardcoded placeholder `'NA'` at initial order creation time, before brokering is known. **TODO**: revisit before production — see [implementation_plan.md](./implementation_plan.md) field mapping tables. The brokered/fulfilled-items feeds documented below (5.1, 5.2) supply the real warehouse once brokering completes.
+
+> [!NOTE]
+> **Open verification item**: if an order item's facility isn't mapped into either the WMS-only or OMS fulfillment facility groups, `HcFulfillmentType` is omitted entirely (neither `OMS` nor `WMS`) rather than defaulting to one or erroring. Since the OMS packing-slip batch job (5.1) filters specifically on `HcFulfillmentType = OMS`, such a line would not be picked up by that batch — and it's unconfirmed what happens to it on the D365/WMS side either. Worth confirming facility-mapping completeness before go-live.
 
 ```
 OMS Brokers Order Items
@@ -240,9 +337,10 @@ Store-fulfilled order items are physically picked, packed, and shipped within OM
 > If the order was already brokered to a store when it was first synced to D365, `HcFulfillmentType = OMS` is set on the line at initial order creation time. The fulfilled items feed reinforces this value and adds the final `SHIPPINGWAREHOUSEID`.
 
 4. **D365 posts the packing slip** via an OOTB batch job filtered on the custom field `HcFulfillmentType = OMS`:
-   - Navigation: `Sales and marketing > Order shipping > Post packing slip`
+   - Navigation: `Sales and marketing > Sales Orders > Order shipping > Post Packing Slip`
    - Query filters: `Sales Order Line HC Fulfillment Type = OMS`, Sales Order status = `Open order, Delivered`
-   - Validated — see issue [#15](https://github.com/hotwax/dynamics365-integration/issues/15).
+   - Navigation (Monitoring/Troubleshooting): `System Administration > Inquiries > Batch Jobs` — find the job, then **Batch Job History** for prior runs, then **Logs > Message Details** for success/failure reasons.
+   - Validated — see issue [#15](https://github.com/hotwax/dynamics365-integration/issues/15) and configuration steps in [#14](https://github.com/hotwax/dynamics365-integration/issues/14).
 5. The packing slip marks these lines as **Delivered** in D365, making them eligible for the invoice batch.
 
 ### 5.2 Warehouse Fulfillment (D365/WMS-Side)
@@ -262,6 +360,7 @@ Warehouse-fulfilled order items are handed off to D365 after brokering. D365 own
 
 > [!NOTE]
 > Reservation is currently configured as `Manual` in the tested D365 setup (`AR > Parameters > General > Sales default values > Reservation`). Sending the brokered warehouse location does not automatically trigger reservation. Reservation remains an ERP-side operational step performed before warehouse picking begins.
+> - **Navigation (Reserve Lot)**: On the sales order, `Sales order lines` FastTab → **Inventory** menu → **Reservation** → **Reserve lot**.
 
 ### 5.3 Mixed Cart Handling
 
@@ -287,10 +386,11 @@ A single OOTB D365 batch job handles invoice posting for all order lines regardl
 - **Quantity**: `Packing slip` — invoices only the quantities confirmed by packing slip.
 - **Late selection**: `Yes` — query re-evaluates at each run, not only at job creation time.
 - **Scope**: Covers both OMS-fulfilled lines (packing slip posted by HC batch) and WMS-fulfilled lines (packing slip posted by D365 warehouse operations).
-- Validated in issues [#16](https://github.com/hotwax/dynamics365-integration/issues/16) (POS) and [#17](https://github.com/hotwax/dynamics365-integration/issues/17) (HC fulfilled).
+- **Navigation (Monitoring/Troubleshooting)**: `System Administration > Inquiries > Batch Jobs` — find the job, then **Batch Job History** for prior runs, then **Logs > Message Details** for success/failure reasons.
+- OOTB batch capability was validated in issues [#16](https://github.com/hotwax/dynamics365-integration/issues/16) (POS) and [#17](https://github.com/hotwax/dynamics365-integration/issues/17) (HC fulfilled), which originally configured two separately-filtered jobs (`SalesOrigin = POS` and `HcFulfillmentType = OMS`). Per a later decision (see comments on both issues), a **single unfiltered job** is used for now since invoicing should run uniformly for all orders regardless of fulfillment origin. The filtered two-job configuration remains available if distinct invoicing cadences are needed later.
 
 > [!NOTE]
-> The current invoice batch job has no filter on `HcFulfillmentType` — it picks up all `Delivered` lines. If separate invoicing cadences for store-fulfilled vs. warehouse-fulfilled lines are needed in future, separate batch jobs with distinct query filters can be configured.
+> The current invoice batch job has no filter on `HcFulfillmentType` — it picks up all `Delivered` lines regardless of fulfillment origin, by design. If separate invoicing cadences for store-fulfilled vs. warehouse-fulfilled lines are needed in future, the previously-configured filtered jobs from issues #16/#17 can be reinstated.
 
 ### 6.2 Multi-Invoice Scenario
 
@@ -330,9 +430,12 @@ The following questions should be clarified with the D365 Finance/Functional tea
 ### 8.2 Customer Groups (CustomerGroupId)
 - Which **Customer Groups** should be assigned to customers synced from HotWax?
 - Will all digital/B2C customers use a single group (e.g., `DEFLT`), or are there multiple groups based on customer categorization?
+- **Framing note**: Customer groups are typically segmented by *channel* (e.g., Wholesale, Retail, Internet, Employees), not by individual customer or customer type. For a pure B2C/digital business, this usually collapses to a single group covering all HotWax-synced customers, unless the client's finance team needs distinct GL/tax treatment per channel (e.g., ecommerce vs. marketplace). See [Create a default customer](https://learn.microsoft.com/en-us/dynamics365/commerce/default-customer) for Microsoft's reference customer-group examples.
+- Does `CustomerGroupId 30` have a default **Sales tax group** or **credit limit type** configured? (See [2.6](#26-sales-tax-group-risk-destination-based-tax) and [2.7](#27-credit-management-interaction) above.)
 
 ### 8.3 Financial Configuration
 - What is the default **Sales Currency Code** (e.g., USD, EUR) to be used for these customers? Does it vary by legal entity?
+- **Note**: `CurrencyCode` is currently hardcoded to `'USD'` in both customer creation (§2) and payment journal creation (§4.1) — this question applies to both, not just customer sync.
 - [ ] Can you confirm whether the current environment allows caller-provided `CustomerAccount` values for customer creation?
 - [ ] If the target state is **Automatic** numbering with **Manual = No**, when should the connector be updated to stop sending `CustomerAccount`?
 
@@ -363,3 +466,7 @@ After D365 posts the packing slip for warehouse-fulfilled order lines, OMS must 
 | Custom flat entity → DMF recurring export → OMS | **Selected** | Chosen for line-level `HcFulfillmentType` filtering and single-export payload completeness (header + lines + tracking) |
 
 For full D365 entity design, field mappings, and OMS processing logic, see [shipment_export_exploration.md](./shipment_export_exploration.md).
+
+### 9.2 Invoice Posting Notification (Future)
+
+Not yet implemented. Preliminary technical exploration exists — see [implementation_plan.md — Outbound Integration (Business Events) TODO](./implementation_plan.md) for the current plan: registering a Moqui REST endpoint, configuring D365 Business Event endpoints, and activating the relevant event (e.g. `SalesOrderInvoicedBusinessEvent`).

--- a/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
+++ b/project-ideas/dynamics365-integration/sales-orders/implementation_plan.md
@@ -104,6 +104,13 @@ This sales-order implementation plan focuses on the sales-order-specific service
 | `CustomerGroupId` | `'30'`                    | **TODO**: Needs discussion. Currently hardcoded to `30` as it's not yet mapped in OMS. |
 | `SalesTaxGroup`   | `''` (Empty String)       | **TODO**: Needs mapping. Expected to be something like `AVATAX`. |
 
+### Related Business Risks
+
+The following are business-process-level risks, not field-mapping gaps — full detail lives in `business_processes.md`, not duplicated here:
+
+- **Sales tax group / destination-based tax**: see [business_processes.md §2.6](business_processes.md#26-sales-tax-group-risk-destination-based-tax).
+- **Credit management / credit limit blocking**: see [business_processes.md §2.7](business_processes.md#27-credit-management-interaction).
+- **Customer change-approval workflow**: see [business_processes.md §2.8](business_processes.md#28-customer-change-approval-workflow).
 
 ## Sales Order Flows
 
@@ -224,7 +231,7 @@ This is a fully implemented direct-sync path that creates a sales order header a
 | `CurrencyCode` | `orderDetail.currencyCode` | Defaults to `USD` if missing. |
 | `IsDeliveryAddressOrderSpecific` | Hardcoded `'Yes'` | Uses order-scoped delivery address. |
 | `DeliveryAddressName` | `orderDetail.toName` | Ship-to name. |
-| `DeliveryAddressDescription` | Hardcoded `'OMS Ship To'` | Fixed value. |
+| `DeliveryAddressDescription` | Hardcoded `'OMS Ship To'` | Fixed value. **TODO**: revisit — confirm whether this should remain a fixed literal or be configurable. |
 | `DeliveryAddressStreet` | `address1 + address2` | Concatenated address lines. |
 | `DeliveryAddressCity` | `orderDetail.city` | |
 | `DeliveryAddressStateId` | Normalized `stateProvinceGeoId` | Strips OMS prefixes when present. |
@@ -247,7 +254,7 @@ This is a fully implemented direct-sync path that creates a sales order header a
 | `ProductColorId` | `ProductFeature(COLOR)` | Sent when the OMS item exposes a color feature. |
 | `shipmentMethodTypeId` | `OrderItemShipGroup.shipmentMethodTypeId` | Used to derive the order-level `DeliveryModeCode`. |
 | `ShippingWarehouseId` | `item.shippingWarehouseId` | Populated only when `HcFulfillmentType = WMS`; empty string otherwise. |
-| `HcFulfillmentType` | `D365MappingWorker.getHcFulfillmentType(facilityId)` | Set at order creation time if the fulfillment path is already known: `WMS` (facility in `WH_ONLY_FULFILLMENT`), `OMS` (facility in `OMS_FULFILLMENT`), or omitted if not yet brokered. Will be set later by the brokered/fulfilled item update feeds. |
+| `HcFulfillmentType` | `D365MappingWorker.getHcFulfillmentType(facilityId)` | Set at order creation time if the fulfillment path is already known: `WMS` (facility in `WH_ONLY_FULFILLMENT`), `OMS` (facility in `OMS_FULFILLMENT`), or omitted if not yet brokered. Will be set later by the brokered/fulfilled item update feeds. **Open question**: if a facility is missing from both groups, the field is also omitted — indistinguishable from the "not yet brokered" case. Such a line would be skipped by the packing-slip batch job's `HcFulfillmentType = OMS` filter. Facility-mapping completeness needs to be confirmed, not just brokering timing. |
 
 ##### OData Idempotency and Failure Behavior
 - **Header idempotency key**: `CustomersOrderReference`
@@ -622,7 +629,7 @@ After OMS confirms the remote execution and completes follow-up processing, the 
 | `INVOICECUSTOMERACCOUNTNUMBER` | Resolved D365 customer account | Same as ordering customer account. |
 | `CURRENCYCODE` | `orderDetail.currencyCode` | Defaults to `USD`. |
 | `DELIVERYADDRESSNAME` | `orderDetail.toName` | |
-| `DELIVERYADDRESSDESCRIPTION` | Hardcoded `'OMS Ship To'` | Fixed value. |
+| `DELIVERYADDRESSDESCRIPTION` | Hardcoded `'OMS Ship To'` | Fixed value. **TODO**: revisit — confirm whether this should remain a fixed literal or be configurable. |
 | `DELIVERYADDRESSSTREET` | `address1 + address2` | Concatenated address. |
 | `DELIVERYADDRESSCITY` | `orderDetail.city` | |
 | `DELIVERYADDRESSSTATEID` | Normalized `stateProvinceGeoId` | |
@@ -644,7 +651,7 @@ After OMS confirms the remote execution and completes follow-up processing, the 
 | `PRODUCTCOLORID` | `ProductFeature(COLOR)` | Sent when the OMS item exposes a color feature. |
 | `shipmentMethodTypeId` | `OrderItemShipGroup.shipmentMethodTypeId` | Used to derive the order-level `DELIVERYMODECODE`. |
 | `SHIPPINGWAREHOUSEID` | `shippingWarehouseId` | Populated only when `HCFULFILLMENTTYPE = WMS`; empty string otherwise. |
-| `HCFULFILLMENTTYPE` | `D365MappingWorker.getHcFulfillmentType(facilityId)` | Set at order creation time if the fulfillment path is already known: `WMS` (facility in `WH_ONLY_FULFILLMENT`), `OMS` (facility in `OMS_FULFILLMENT`), or omitted if not yet brokered. Will be set later by the brokered/fulfilled item update feeds. |
+| `HCFULFILLMENTTYPE` | `D365MappingWorker.getHcFulfillmentType(facilityId)` | Set at order creation time if the fulfillment path is already known: `WMS` (facility in `WH_ONLY_FULFILLMENT`), `OMS` (facility in `OMS_FULFILLMENT`), or omitted if not yet brokered. Will be set later by the brokered/fulfilled item update feeds. **Open question**: if a facility is missing from both groups, the field is also omitted — indistinguishable from the "not yet brokered" case. Such a line would be skipped by the packing-slip batch job's `HcFulfillmentType = OMS` filter. Facility-mapping completeness needs to be confirmed, not just brokering timing. |
 
 ###### DMF Shipment Method Handling
 - The eligible-order view also exposes `isMixCartOrder` so order-level delivery mode can be derived consistently.
@@ -673,7 +680,7 @@ After OMS confirms the remote execution and completes follow-up processing, the 
 | XML Attribute | Mapping from OMS | Usage / Notes |
 | :--- | :--- | :--- |
 | `FIXEDCHARGEAMOUNT` | Calculated shipping charge | Defaults to `0` if missing. |
-| `SALESCHARGECODE` | Hardcoded `'FREIGHT'` | Fixed value in current implementation. |
+| `SALESCHARGECODE` | Hardcoded `'FREIGHT'` | Fixed value in current implementation. **TODO**: revisit — confirm this should remain a fixed literal rather than be sourced from configuration; also confirm a `FREIGHT` charges code exists in the target D365 environment (`Accounts receivable > Charges setup > Charges code`). |
 
 ##### DMF Package and Import Details
 - **Generated files**:
@@ -1298,7 +1305,7 @@ Creates journal headers and lines via direct OData REST calls. Supports an optio
 | D365 Field | OMS / Moqui Source | Notes |
 | :--- | :--- | :--- |
 | `dataAreaId` | `ProductStore.externalId` | Legal entity context. |
-| `JournalName` | `"OMSPAY"` | Fixed. |
+| `JournalName` | `"OMSPAY"` | Fixed. **TODO**: revisit — confirm this should remain a fixed literal rather than be sourced from configuration. |
 | `Description` | `"OMS Payment Journal - SO <d365SalesOrderNumber>"` | Idempotency lookup key. |
 
 #### Line (`CustomerPaymentJournalLines`)
@@ -1309,7 +1316,7 @@ Creates journal headers and lines via direct OData REST calls. Supports an optio
 | `JournalBatchNumber` | Returned from header POST | Links line to header. |
 | `AccountType` | `"Cust"` | Fixed. |
 | `AccountDisplayValue` | `"HW\\-" + partyId` | Backslash-escaped to avoid OData filter issues. |
-| `CurrencyCode` | `"USD"` | Currently defaulted. |
+| `CurrencyCode` | `"USD"` | Currently defaulted. **TODO**: revisit alongside the open Sales Currency Code question in `business_processes.md` §8.3 — this hardcode affects payments, not just customer creation. |
 | `CreditAmount` | `OrderPaymentPreference.maxAmount` | Payment amount. |
 | `IsPrepayment` | `"No"` | On-account flow. |
 | `PaymentReference` | `d365SalesOrderNumber` | Settlement anchor. |
@@ -1435,8 +1442,8 @@ The order will be sent to D365 as part of the [Sales Order Sync](#sales-order-sy
 
 ### Implementation Strategy: OOTB vs. Custom Code
 
-- **Automated Packing Slip Posting**: Handled by OOTB D365 batch job (`Sales and marketing > Post packing slip`, filtered by `SalesOrigin = POS`). Validated — see issue [#13](https://github.com/hotwax/dynamics365-integration/issues/13).
-- **Automated Invoice Posting**: Handled by OOTB D365 batch job (`AR > Invoices > Batch invoicing > Invoice`, filtered by `SalesOrigin = POS`). Validated — see issue [#16](https://github.com/hotwax/dynamics365-integration/issues/16).
+- **Automated Packing Slip Posting**: Handled by OOTB D365 batch job (`Sales and marketing > Sales Orders > Order shipping > Post Packing Slip`, filtered by `SalesOrigin = POS`). Validated — see issue [#13](https://github.com/hotwax/dynamics365-integration/issues/13).
+- **Automated Invoice Posting**: Handled by OOTB D365 batch job (`AR > Invoices > Batch invoicing > Invoice`). For now, a single unfiltered job posts invoices for all Delivered orders regardless of sales origin or fulfillment type. Filtering by `SalesOrigin = POS` (issue [#16](https://github.com/hotwax/dynamics365-integration/issues/16)) or `HcFulfillmentType = OMS` (issue [#17](https://github.com/hotwax/dynamics365-integration/issues/17)) is possible if separate jobs are configured later, but that's not the current setup — see [business_processes.md §6.1](./business_processes.md#61-invoice-batch-job).
 - **Payment Journal Posting**: Under evaluation — OOTB AR auto-post may be sufficient; to be confirmed in target environment.
 - **Settlement**: Custom `HotWaxAutoPostSettlementService` implemented in the `dynamics365-integration` repository. OOTB settlement was rejected because it uses customer-level FIFO matching, which cannot honor `PaymentReference = SalesOrderNumber`. See [invoice_settlement.md](./invoice_settlement.md) for full design and test results.
 

--- a/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
+++ b/project-ideas/dynamics365-integration/sales-orders/invoice_settlement.md
@@ -93,10 +93,8 @@ For full implementation details — eligibility view, field mappings for both ap
 
 Invoice posting is triggered inside D365 after the packing slip is posted. This is not directly controlled by OMS.
 
-- **Standard OOTB option**: D365 provides a standard batch job to auto-invoice orders that have been packing-slip updated (under `Accounts receivable > Periodic tasks > Update invoices`).
-- **Custom option**: If OOTB batch is insufficient for target automation requirements, custom X++ `SysOperation` logic can be implemented in the `dynamics365-integration` repository.
-
-**Validation TODO**: Confirm in the target D365 environment whether OOTB batch jobs are sufficient to auto-invoice sales orders created via OMS. This depends on D365 AR configuration and whether orders imported through OData/DMF trigger the standard invoice eligibility filter.
+- **Standard OOTB option (validated)**: D365's standard batch invoicing job (`Accounts receivable > Invoices > Batch invoicing > Invoice`) auto-invoices orders that have reached the packing-slip-updated (`Delivered`) state. Validated in issues [#16](https://github.com/hotwax/dynamics365-integration/issues/16) and [#17](https://github.com/hotwax/dynamics365-integration/issues/17) — confirmed sufficient for sales orders created via OMS (OData/DMF), no custom X++ needed.
+- **Job configuration decision**: Issues #16/#17 originally configured two separately-filtered jobs (`SalesOrigin = POS` and `HcFulfillmentType = OMS`). Per a later decision (see comments on both issues), a single unfiltered job is used for now, since invoicing should run uniformly for all orders regardless of fulfillment origin. See [business_processes.md §6.1](./business_processes.md#61-invoice-batch-job) for current details.
 
 ### 4.2 Multi-Invoice Scenario
 
@@ -186,11 +184,15 @@ When multiple payment journal lines cover a single invoice (e.g. gift card + cre
 | Parameter | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `SalesId` | String | No | Restrict settlement to a specific sales order. Useful for targeted re-runs and debugging. |
-| `TransDate` | Date | No | Only settle invoices with `TransDate ≤ this date`. Omit to process all open invoices (default). Supports period-end scoping. |
+| `FromDate` | Date | No | Only settle invoices with `TransDate >= this date` (invoices **on or after** this date). Omit to process all open invoices (default). Supports period-start scoping. |
+
+**Known Caveat — Exchange Order Exclusion**
+
+`HotWaxAutoPostSettlementService.xml` filters on `custInvoiceJour.PurchaseOrder == ""` to exclude invoices related to exchange orders, avoiding a race condition with the separate `HotWaxAutoPostReturnSettlementService`. This repurposes the standard `PurchaseOrder` field on the invoice as an exclusion flag rather than using a dedicated field. The code comments explicitly flag this as a deliberately deferred design decision, not yet resolved with a cleaner approach.
 
 **D365 Setup**
 
-The service runs as a recurring D365 batch job. Access it from the HotWax custom menu extension → **Auto Post Settlement**. Configure the recurrence interval to match the required settlement frequency.
+The service runs as a recurring D365 batch job. Navigation: `System administration > Periodic` → **HotWax Automated Customer Settlement**. Configure the recurrence interval to match the required settlement frequency.
 
 **Status**: Implemented. Scenarios #1–#3, #5, #7, #12, and #13 verified. See [section 8](#8-settlement-test-scenarios) for full test matrix.
 
@@ -207,7 +209,7 @@ The service runs as a recurring D365 batch job. Access it from the HotWax custom
 POS Completed orders require a tightly automated lifecycle since payment is captured at the point of sale. Steps 1–3 use validated OOTB D365 batch jobs; step 4 uses the custom settlement service.
 
 1. OMS pushes sales order to D365.
-2. D365 auto-posts packing slip — OOTB batch (`Sales and marketing > Order shipping > Post packing slip`, filtered by `SalesOrigin = POS`). Validated in issue [#13](https://github.com/hotwax/dynamics365-integration/issues/13).
+2. D365 auto-posts packing slip — OOTB batch (`Sales and marketing > Sales Orders > Order shipping > Post Packing Slip`, filtered by `SalesOrigin = POS`). Validated in issue [#13](https://github.com/hotwax/dynamics365-integration/issues/13).
 3. D365 auto-posts invoice — OOTB batch (`AR > Invoices > Batch invoicing > Invoice`, filtered by `SalesOrigin = POS`). Validated in issue [#16](https://github.com/hotwax/dynamics365-integration/issues/16).
 4. OMS pushes customer payment journal (OData, unposted draft).
 5. D365 posts the payment journal — OOTB AR auto-post batch. Validated.
@@ -230,7 +232,7 @@ POS Completed orders require a tightly automated lifecycle since payment is capt
 
 | Step | Approach | Notes |
 | :--- | :--- | :--- |
-| Packing slip auto-post | OOTB ✓ | Standard D365 batch (`Sales and marketing > Post packing slip`). Validated — see issues #13, #15. |
+| Packing slip auto-post | OOTB ✓ | Standard D365 batch (`Sales and marketing > Sales Orders > Order shipping > Post Packing Slip`). Validated — see issues #13, #15. |
 | Invoice auto-post | OOTB ✓ | Standard D365 batch (`AR > Invoices > Batch invoicing > Invoice`). Validated — see issues #16, #17. |
 | Payment journal post | OOTB ✓ | Standard D365 AR auto-post batch. Validated. |
 | Settlement | Custom ✓ | OOTB rejected (FIFO by customer, ignores `PaymentReference`). Custom `HotWaxAutoPostSettlementService` implemented — see [section 5.2](#52-custom-settlement-service-hotwaxautopostsettlementservice). |
@@ -337,6 +339,7 @@ These scenarios cover the `HotWaxAutoPostSettlementService` custom X++ settlemen
 | Map `paymentMethodTypeId` to D365 bank account codes | Medium | Currently requires manual mapping. Should be driven by `IntegrationTypeMapping`. |
 | Decide on `SalesTaxGroup` mapping | Medium | Currently sent as empty string. Expected D365 value is something like `AVATAX`. |
 | Send common Shopify Order Id on Customer Payment Journal | Medium | Today the payment journal links to a sales order only via `PaymentReference = d365SalesOrderNumber` — no Shopify Order Id is carried on the journal line. NetSuite sends the Shopify Order Id on every related transaction (Sales Order, Customer Deposit, RMA, Credit Memo, Exchange Order) as a common cross-reference; D365 doesn't yet. See `sales-orders/implementation_plan.md` §"OData TODOs / Gaps". |
+| **Open question**: reconciliation/manual-intervention process for over/underpayment | Medium | Overpayment (scenario #5) and underpayment (scenario #6) are currently only documented as end-states — leftover credit in `CustTransOpen`, or an invoice left partially open — with no documented follow-up workflow (who reconciles it, how, and on what cadence). Needs a decision: is this handled by existing D365 collections/credit processes, or does it need a dedicated OMS/D365 process? |
 
 ---
 
@@ -354,7 +357,7 @@ These scenarios cover the `HotWaxAutoPostSettlementService` custom X++ settlemen
 
 ## 11. Related Docs
 
-- [Business Processes](./business_processes.md) — Section 4 (Customer Payment Management) and Section 5 (Fulfillment & Invoicing).
+- [Business Processes](./business_processes.md) — Section 4 (Customer Payment Management), Section 5 (Fulfillment), and Section 6 (Invoicing).
 - [Implementation Plan](./implementation_plan.md) — Customer Payment Integration section and POS Completed Orders Sync section.
 - [D365 Return & Exchange Settlement Integration](../sales-returns/return_invoice_settlement.md) — Settlement behavior for return credit notes.
 - [Connector Foundation](../foundation/connector_foundation.md) — OData client, auth, and request handling shared by the payment sync service.


### PR DESCRIPTION
## Summary
- Clarifies that Customer Group → Customer Posting Profile only resolves the AR/receivable main account for an invoice — revenue, tax, and COGS accounts are separate voucher lines driven independently by item group and sales tax group setup, not by customer group.
- Documents sales tax group risk (destination-based tax), credit management interaction, and the customer change approval workflow for `sync#Customer`.
- Adds navigation/reference notes across sales order sync, delivery address, shipping charge, and customer payment journal sections (D365 menu paths, batch job monitoring, Microsoft Learn references).
- Flags a TODO: send a common Shopify Order Id across Sales Order and Customer Payment Journal, mirroring the pattern already used in the NetSuite integration for this OMS (`custbody_hc_shopify_order_id`), so D365 gains a native cross-transaction reference instead of relying entirely on OMS-side tracking.

## Test plan
- [ ] Confirm the new `> [!NOTE]` callout in `business_processes.md` §2.5 reads consistently with the existing "Relation" bullet above it
- [x] Confirm the three cited Microsoft Learn links resolve
- [x] Spot-check new navigation paths (Batch Jobs, Charges setup, Recurring data job monitoring) against a live D365 environment if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)